### PR TITLE
Low cardinality numerical data is inferred to be ordinal

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export interface QueryConfig {
   /** Default types to enumerate */
   types?: Type[];
 
-  /** Default ratio for numbers to be considered ordinal */
+  /** Default ratio for number fields to be considered ordinal */
   numberOrdinalProportion?: number;
 
   /** Default maxbins to enumerate */

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,9 @@ export interface QueryConfig {
   /** Default types to enumerate */
   types?: Type[];
 
+  /** Default ratio for numbers to be considered ordinal */
+  numberOrdinalProportion?: number;
+
   /** Default maxbins to enumerate */
   maxBinsList?: number[];
 
@@ -90,6 +93,7 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
   aggregates: [undefined, AggregateOp.MEAN],
   timeUnits: [undefined, TimeUnit.YEAR, TimeUnit.MONTH, TimeUnit.DAY, TimeUnit.DATE], // TODO: include hours and minutes
   types: [Type.NOMINAL, Type.ORDINAL, Type.QUANTITATIVE, Type.TEMPORAL],
+  numberOrdinalProportion: .05,
 
   maxBinsList: [5, 10, 20],
   scaleTypes: [ScaleType.LINEAR, ScaleType.LOG],

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -40,7 +40,7 @@ export class Schema {
             min = Math.min(min, dataPoints[i]);
             max = Math.max(max, dataPoints[i]);
           }
-          type = max - min == dataPoints.length - 1 ? Type.NOMINAL : Type.ORDINAL;
+          type = max - min === dataPoints.length - 1 ? Type.NOMINAL : Type.ORDINAL;
         } else {
           type = Type.QUANTITATIVE;
         }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -33,7 +33,7 @@ export class Schema {
       } else if (primitiveType === PrimitiveType.INTEGER) {
         // use ordinal or nominal when cardinality of integer type is relatively low
         if (distinct / summary.count < opt.numberOrdinalProportion) {
-          // use nominal if the data is in order, ordinal otherwise
+          // use nominal if the integers are 1,2,3,...,N where N = cardinality
           var dataPoints: number[] = keys(summary.unique) as any;
           var min = dataPoints[0], max = dataPoints[0];
           for (var i = 1; i < dataPoints.length; i++) {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -3,6 +3,8 @@ import {summary} from 'datalib/src/stats';
 import {inferAll} from 'datalib/src/import/type';
 
 import {EncodingQuery} from './query';
+import {QueryConfig, DEFAULT_QUERY_CONFIG} from './config';
+import {extend} from './util';
 
 export class Schema {
   private fieldSchemas: FieldSchema[];
@@ -14,7 +16,9 @@ export class Schema {
    * @param data - a set of raw data
    * @return a Schema object
    */
-  public static build(data: any): Schema {
+  public static build(data: any, opt: QueryConfig = {}): Schema {
+    opt = extend({}, DEFAULT_QUERY_CONFIG, opt);
+
     // create profiles for each variable
     var summaries: Summary[] = summary(data);
     var types = inferAll(data); // inferAll does stronger type inference than summary
@@ -22,9 +26,18 @@ export class Schema {
     var fieldSchemas: FieldSchema[] = summaries.map(function(summary) {
       var field: string = summary.field;
       var primitiveType: PrimitiveType = types[field] as any;
-      var type: Type = (primitiveType === PrimitiveType.NUMBER || primitiveType === PrimitiveType.INTEGER) ? Type.QUANTITATIVE:
-        primitiveType === PrimitiveType.DATE ? Type.TEMPORAL : Type.NOMINAL;
-
+      var distinct: number = summary.distinct;
+      var type: Type;
+      if (primitiveType === PrimitiveType.NUMBER) {
+        type = Type.QUANTITATIVE;
+      } else if (primitiveType === PrimitiveType.INTEGER) {
+        // use ordinal when cardinality of integer type is relatively low
+        type = (distinct / summary.count < opt.numberOrdinalProportion) ? Type.ORDINAL : Type.QUANTITATIVE; // use config, not hard coded number
+      } else if (primitiveType === PrimitiveType.DATE) {
+        type = Type.TEMPORAL;
+      } else {
+        type = Type.NOMINAL;
+      }
       return {
         field: field,
         type: type,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -4,7 +4,7 @@ import {inferAll} from 'datalib/src/import/type';
 
 import {EncodingQuery} from './query';
 import {QueryConfig, DEFAULT_QUERY_CONFIG} from './config';
-import {extend} from './util';
+import {contains, extend} from './util';
 
 export class Schema {
   private fieldSchemas: FieldSchema[];
@@ -33,8 +33,8 @@ export class Schema {
       } else if (primitiveType === PrimitiveType.INTEGER) {
         // use ordinal or nominal when cardinality of integer type is relatively low
         if (distinct / summary.count < opt.numberOrdinalProportion) {
-          // use nominal if the integers are 1,2,3,...,N where N = cardinality
-          type = summary.max - summary.min === distinct - 1 ? Type.NOMINAL : Type.ORDINAL;
+          // use nominal if the integers are 1,2,3,...,N or 0,1,2,3,...,N-1 where N = cardinality
+          type = (summary.max - summary.min === distinct - 1 && contains([0,1], summary.min)) ? Type.NOMINAL : Type.ORDINAL;
         } else {
           type = Type.QUANTITATIVE;
         }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -34,13 +34,7 @@ export class Schema {
         // use ordinal or nominal when cardinality of integer type is relatively low
         if (distinct / summary.count < opt.numberOrdinalProportion) {
           // use nominal if the integers are 1,2,3,...,N where N = cardinality
-          var dataPoints: number[] = keys(summary.unique) as any;
-          var min = dataPoints[0], max = dataPoints[0];
-          for (var i = 1; i < dataPoints.length; i++) {
-            min = Math.min(min, dataPoints[i]);
-            max = Math.max(max, dataPoints[i]);
-          }
-          type = max - min === dataPoints.length - 1 ? Type.NOMINAL : Type.ORDINAL;
+          type = summary.max - summary.min === distinct - 1 ? Type.NOMINAL : Type.ORDINAL;
         } else {
           type = Type.QUANTITATIVE;
         }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -4,7 +4,7 @@ import {inferAll} from 'datalib/src/import/type';
 
 import {EncodingQuery} from './query';
 import {QueryConfig, DEFAULT_QUERY_CONFIG} from './config';
-import {extend, keys} from './util';
+import {extend} from './util';
 
 export class Schema {
   private fieldSchemas: FieldSchema[];

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -52,6 +52,7 @@ describe('schema', () => {
       assert.equal(schema.type('c'), Type.QUANTITATIVE);
       assert.equal(schema.type('d'), Type.TEMPORAL);
     });
+    
     it('should infer nominal type for integers when cardinality is much less than the total', () => {
       const numberData = [];
       // add enough non-distinct data to make the field ordinal
@@ -62,6 +63,7 @@ describe('schema', () => {
       const numberSchema = Schema.build(numberData);
       assert.equal(numberSchema.type('a'), Type.NOMINAL);
     });
+    
     it('should infer nominal type for integers when cardinality is much less than the total and numbers are in order', () => {
       const numberData = [];
       // add enough non-distinct data to make the field ordinal and have multiple in-order keys
@@ -74,6 +76,7 @@ describe('schema', () => {
       const numberSchema = Schema.build(numberData);
       assert.equal(numberSchema.type('a'), Type.NOMINAL);
     });
+    
     it('should infer ordinal type for integers when cardinality is much less than the total and numbers are not in order', () => {
       const numberData = [];
       // add enough non-distinct data to make the field ordinal and have multiple in-order keys

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -89,6 +89,19 @@ describe('schema', () => {
       const numberSchema = Schema.build(numberData);
       assert.equal(numberSchema.type('a'), Type.ORDINAL);
     });
+
+    it('should not infer nominal type if the number set does not contain 0 or 1', () => {
+      const numberData = [];
+      // add enough non-distinct data to make the field nominal and have multiple in-order keys, but not contain 0 or 1
+      var total = 3 * (1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1);
+      for (var i = 0; i < total; i++) {
+        numberData.push({a: 2});
+        numberData.push({a: 3});
+        numberData.push({a: 4});
+      }
+      const numberSchema = Schema.build(numberData);
+      assert.equal(numberSchema.type('a'), Type.ORDINAL);
+    });
   });
 
   describe('cardinality', () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -52,7 +52,7 @@ describe('schema', () => {
       assert.equal(schema.type('c'), Type.QUANTITATIVE);
       assert.equal(schema.type('d'), Type.TEMPORAL);
     });
-    
+
     it('should infer nominal type for integers when cardinality is much less than the total', () => {
       const numberData = [];
       // add enough non-distinct data to make the field ordinal
@@ -63,7 +63,7 @@ describe('schema', () => {
       const numberSchema = Schema.build(numberData);
       assert.equal(numberSchema.type('a'), Type.NOMINAL);
     });
-    
+
     it('should infer nominal type for integers when cardinality is much less than the total and numbers are in order', () => {
       const numberData = [];
       // add enough non-distinct data to make the field nominal and have multiple in-order keys
@@ -76,7 +76,7 @@ describe('schema', () => {
       const numberSchema = Schema.build(numberData);
       assert.equal(numberSchema.type('a'), Type.NOMINAL);
     });
-    
+
     it('should infer ordinal type for integers when cardinality is much less than the total and numbers are not in order', () => {
       const numberData = [];
       // add enough non-distinct data to make the field ordinal and have multiple in-order keys
@@ -105,6 +105,7 @@ describe('schema', () => {
       const summary: Summary = schema.stats({field: 'foo', channel: Channel.X});
       assert.isNull(summary);
     });
+
     it('should return the correct summary for a valid EncodingQuery', () => {
       const summary: Summary = schema.stats({field: 'a', channel: Channel.X});
       assert.isNotNull(summary);

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -55,7 +55,7 @@ describe('schema', () => {
 
     it('should infer nominal type for integers when cardinality is much less than the total', () => {
       const numberData = [];
-      // add enough non-distinct data to make the field ordinal
+      // add enough non-distinct data to make the field nominal
       var total = 1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1;
       for (var i = 0; i < total; i++) {
         numberData.push({a: 1});
@@ -64,9 +64,24 @@ describe('schema', () => {
       assert.equal(numberSchema.type('a'), Type.NOMINAL);
     });
 
-    it('should infer nominal type for integers when cardinality is much less than the total and numbers are in order', () => {
+    it('should infer nominal type for integers when cardinality is much less than the total and numbers are in order, starts at 0, and have no skipping', () => {
       const numberData = [];
-      // add enough non-distinct data to make the field nominal and have multiple in-order keys
+      // add enough non-distinct data to make the field nominal/ordinal and have multiple in-order, non-skipping values that starts at 0
+      // (and by default, we set them to nominal)
+      var total = 3 * (1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1);
+      for (var i = 0; i < total; i++) {
+        numberData.push({a: 0});
+        numberData.push({a: 1});
+        numberData.push({a: 2});
+      }
+      const numberSchema = Schema.build(numberData);
+      assert.equal(numberSchema.type('a'), Type.NOMINAL);
+    });
+
+    it('should infer nominal type for integers when cardinality is much less than the total and numbers are in order, starts at 1, and have no skipping', () => {
+      const numberData = [];
+      // add enough non-distinct data to make the field nominal/ordinal and have multiple in-order, non-skipping values that starts at 1
+      // (and by default, we set them to nominal)
       var total = 3 * (1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1);
       for (var i = 0; i < total; i++) {
         numberData.push({a: 1});
@@ -79,7 +94,7 @@ describe('schema', () => {
 
     it('should infer ordinal type for integers when cardinality is much less than the total and numbers are not in order', () => {
       const numberData = [];
-      // add enough non-distinct data to make the field ordinal and have multiple in-order keys
+      // add enough non-distinct data to make the field ordinal and have multiple in-order, with skipping values
       var total = 3 * (1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1);
       for (var i = 0; i < total; i++) {
         numberData.push({a: 1});
@@ -92,7 +107,7 @@ describe('schema', () => {
 
     it('should not infer nominal type if the number set does not contain 0 or 1', () => {
       const numberData = [];
-      // add enough non-distinct data to make the field nominal and have multiple in-order keys, but not contain 0 or 1
+      // add enough non-distinct data to make the field ordinal and have multiple in-order, non-skipping values that do not start with 0 or 1
       var total = 3 * (1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1);
       for (var i = 0; i < total; i++) {
         numberData.push({a: 2});

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -52,12 +52,36 @@ describe('schema', () => {
       assert.equal(schema.type('c'), Type.QUANTITATIVE);
       assert.equal(schema.type('d'), Type.TEMPORAL);
     });
-    it('should infer ordinal type for integers when cardinality is much less than the total', () => {
+    it('should infer nominal type for integers when cardinality is much less than the total', () => {
       const numberData = [];
       // add enough non-distinct data to make the field ordinal
       var total = 1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1;
       for (var i = 0; i < total; i++) {
         numberData.push({a: 1});
+      }
+      const numberSchema = Schema.build(numberData);
+      assert.equal(numberSchema.type('a'), Type.NOMINAL);
+    });
+    it('should infer nominal type for integers when cardinality is much less than the total and numbers are in order', () => {
+      const numberData = [];
+      // add enough non-distinct data to make the field ordinal and have multiple in-order keys
+      var total = 3 * (1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1);
+      for (var i = 0; i < total; i++) {
+        numberData.push({a: 1});
+        numberData.push({a: 2});
+        numberData.push({a: 3});
+      }
+      const numberSchema = Schema.build(numberData);
+      assert.equal(numberSchema.type('a'), Type.NOMINAL);
+    });
+    it('should infer ordinal type for integers when cardinality is much less than the total and numbers are not in order', () => {
+      const numberData = [];
+      // add enough non-distinct data to make the field ordinal and have multiple in-order keys
+      var total = 3 * (1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1);
+      for (var i = 0; i < total; i++) {
+        numberData.push({a: 1});
+        numberData.push({a: 3});
+        numberData.push({a: 5});
       }
       const numberSchema = Schema.build(numberData);
       assert.equal(numberSchema.type('a'), Type.ORDINAL);

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -66,7 +66,7 @@ describe('schema', () => {
     
     it('should infer nominal type for integers when cardinality is much less than the total and numbers are in order', () => {
       const numberData = [];
-      // add enough non-distinct data to make the field ordinal and have multiple in-order keys
+      // add enough non-distinct data to make the field nominal and have multiple in-order keys
       var total = 3 * (1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1);
       for (var i = 0; i < total; i++) {
         numberData.push({a: 1});

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -4,6 +4,7 @@ import {Type} from 'vega-lite/src/type';
 import {Channel} from 'vega-lite/src/channel';
 
 import {Schema, PrimitiveType} from '../src/schema';
+import {DEFAULT_QUERY_CONFIG} from '../src/config';
 
 describe('schema', () => {
 
@@ -50,6 +51,16 @@ describe('schema', () => {
       assert.equal(schema.type('b'), Type.NOMINAL);
       assert.equal(schema.type('c'), Type.QUANTITATIVE);
       assert.equal(schema.type('d'), Type.TEMPORAL);
+    });
+    it('should infer ordinal type for integers when cardinality is much less than the total', () => {
+      const numberData = [];
+      // add enough non-distinct data to make the field ordinal
+      var total = 1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1;
+      for (var i = 0; i < total; i++) {
+        numberData.push({a: 1});
+      }
+      const numberSchema = Schema.build(numberData);
+      assert.equal(numberSchema.type('a'), Type.ORDINAL);
     });
   });
 


### PR DESCRIPTION
Fix #88

1. Fields with integer primitive type are inferred to be ordinal if (distinct / total count) is less than a given percentage.
2. `Schema.build` takes in an optional `QueryConfig` options object.
3. Default percentage is specified in config.ts (5%)
4. Wrote tests for behavior in (1)