### PR TITLE
Refactor API

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -4,11 +4,8 @@ import {QueryConfig, DEFAULT_QUERY_CONFIG} from './config';
 import {SpecQueryModel} from './model';
 import {SpecQuery} from './query';
 import {Schema} from './schema';
-import {extend} from './util';
 
-export function generate(specQ: SpecQuery, schema: Schema, opt: QueryConfig = {}) {
-  opt = extend({}, DEFAULT_QUERY_CONFIG, opt);
-
+export function generate(specQ: SpecQuery, schema: Schema, opt: QueryConfig = DEFAULT_QUERY_CONFIG) {
   // 1. Build a SpecQueryModel, which also contains enumSpecIndex
   const specM = SpecQueryModel.build(specQ, schema, opt);
   const enumSpecIndex = specM.enumSpecIndex;

--- a/src/model.ts
+++ b/src/model.ts
@@ -146,8 +146,6 @@ export class SpecQueryModel {
    * @return a SpecQueryModel that wraps the specQuery and the enumSpecIndex.
    */
   public static build(specQ: SpecQuery, schema: Schema, opt: QueryConfig): SpecQueryModel {
-    specQ = duplicate(specQ); // preventing side-effect
-
     let enumSpecIndex: EnumSpecIndex = {};
 
     // mark

--- a/test/enumerator.test.ts
+++ b/test/enumerator.test.ts
@@ -8,7 +8,6 @@ import {TimeUnit} from 'vega-lite/src/timeunit';
 import {Type} from 'vega-lite/src/type';
 
 import {DEFAULT_QUERY_CONFIG} from '../src/config';
-import {generate} from '../src/generate';
 import {ENUMERATOR_INDEX} from '../src/enumerator';
 import {SpecQueryModel} from '../src/model';
 import {BinQuery, ScaleQuery, SpecQuery} from '../src/query';
@@ -478,63 +477,6 @@ describe('enumerator', () => {
         const answerSet = enumerator([], specM);
         assert.equal(answerSet.length, 1);
         assert.equal(answerSet[0].getEncodingQueryByIndex(0).type, Type.NOMINAL);
-      });
-    });
-  });
-
-  describe('autoAddCount', () => {
-    describe('ordinal only', () => {
-      it('should output autoCount in the answer set', () => {
-        const query = {
-          mark: Mark.POINT,
-          encodings: [
-              { channel: Channel.X, field: 'O', type: Type.ORDINAL},
-          ]
-        };
-        const answerSet = generate(query, schema, {autoAddCount: true});
-        assert.equal(answerSet.length, 1);
-        assert.isTrue(answerSet[0].getEncodings()[1].autoCount);
-      });
-    });
-
-    describe('non-binned quantitative only', () => {
-      const query = {
-        mark: Mark.POINT,
-        encodings: [
-          { channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
-        ]
-      };
-      const answerSet = generate(query, schema, {autoAddCount: true});
-
-      it('should output autoCount=false', () => {
-        assert.isFalse(answerSet[0].getEncodingQueryByIndex(1).autoCount);
-      });
-
-      it('should not output duplicate results in the answer set', () => {
-        assert.equal(answerSet.length, 1);
-      });
-    });
-
-    describe('enumerate channel for a non-binned quantitative field', () => {
-      const query = {
-        mark: Mark.POINT,
-        encodings: [
-          {
-            channel: {values: [Channel.X, Channel.SIZE, Channel.COLOR]},
-            field: 'Q',
-            type: Type.QUANTITATIVE
-          }
-        ]
-      };
-      const answerSet = generate(query, schema, {autoAddCount: true});
-
-      it('should not output point with only size for color', () => {
-        answerSet.forEach((model) => {
-          model.getEncodings().forEach((encQ) => {
-            assert.notEqual(encQ.channel, Channel.COLOR);
-            assert.notEqual(encQ.channel, Channel.SIZE);
-          });
-        });
       });
     });
   });

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -22,16 +22,6 @@ describe('SpecQueryModel', () => {
   }
 
   describe('build', () => {
-    it('should not cause side effect to the original query object.', () => {
-      const specQ: SpecQuery = {
-        mark: SHORT_ENUM_SPEC,
-        encodings: []
-      };
-      const specQueryModel = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG);
-      assert.equal(specQ.mark, SHORT_ENUM_SPEC);
-      assert.notEqual(specQ.mark, specQueryModel.specQuery);
-    });
-
     // Mark
     it('should have mark enumSpecIndex if mark is a ShortEnumSpec.', () => {
       const specQ: SpecQuery = {

--- a/test/nest.test.ts
+++ b/test/nest.test.ts
@@ -336,10 +336,10 @@ describe('nest', () => {
             }]
           },
           nest: [{groupBy: groupBy}],
-          config: DEFAULT_QUERY_CONFIG
+          config: extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOverPositionalChannels: false})
         };
 
-        const answerSet = generate(query.spec, schema, {omitNonPositionalOverPositionalChannels: false});
+        const answerSet = generate(query.spec, schema, query.config);
         const groups = nest(answerSet, query).items;
         assert.equal(groups.length, 2);
       });


### PR DESCRIPTION
- `query()` should return augmented `query` in addition to the `result: SpecQueryModelGroup`.
-  config inside `query()` instead of generate for consistent config
- No longer worried about causing side effect in `SpecQueryModel.build()` as we only have to prevent side effect to the original `q: Query`
- make required `duplicate()` in `query.normalize()`

- Fix test + move leftover generate test in `enumerate.test.ts` to `generate.test.ts`