### PR TITLE
Basic Support for scale.* properties

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,11 @@ export interface QueryConfig {
 
   scaleClamps?: boolean[];
 
+  scaleDomains?: Array<string | number[] | string[]>;
+
   scaleExponents?: number[];
+
+  scaleRanges?: Array<string | number[] | string[]>;
 
   scaleRounds?: boolean[];
 
@@ -108,6 +112,10 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
   maxBinsList: [5, 10, 20],
 
   scaleBandSizes: [17, 21],
+
+  scaleDomains: [undefined],
+
+  scaleRanges: [undefined],
 
   scaleExponents: [0.5, 1, 2],
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,8 @@ export interface QueryConfig {
 
   scaleTypes?: ScaleType[];
 
+  scaleUseRawDomains?: boolean[];
+
   scaleZeros?: boolean[];
 
   // SPECIAL MODE

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,10 @@ export interface QueryConfig {
 
   scaleBandSizes?: number[];
 
+  scaleClamps?: boolean[];
+
+  scaleExponents?: number[];
+
   scaleRounds?: boolean[];
 
   scaleTypes?: ScaleType[];
@@ -102,7 +106,11 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
   numberOrdinalProportion: .05,
 
   maxBinsList: [5, 10, 20],
+
   scaleBandSizes: [17, 21],
+
+  scaleExponents: [0.5, 1, 2],
+
   scaleTypes: [ScaleType.LINEAR, ScaleType.LOG],
 
   // CONSTRAINTS

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,8 @@ export interface QueryConfig {
 
   scaleExponents?: number[];
 
+  scaleNices?: boolean[];
+
   scaleRanges?: Array<string | number[] | string[]>;
 
   scaleRounds?: boolean[];

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,8 @@ export interface QueryConfig {
 
   scaleBandSizes?: number[];
 
+  scaleRounds?: boolean[];
+
   scaleTypes?: ScaleType[];
 
   scaleZeros?: boolean[];

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ export interface QueryConfig {
 
   propertyPrecedence?: Property[];
 
-  /** Defautl marks to enumerate. */
+  /** Default marks to enumerate. */
   marks?: Mark[];
 
   /** Default channels to enumerate. */
@@ -38,23 +38,13 @@ export interface QueryConfig {
 
   scaleBandSizes?: number[];
 
-  scaleClamps?: boolean[];
-
-  scaleDomains?: Array<string | number[] | string[]>;
+  scaleDomains?: Array<number[] | string[]>;
 
   scaleExponents?: number[];
 
-  scaleNices?: boolean[];
-
   scaleRanges?: Array<string | number[] | string[]>;
 
-  scaleRounds?: boolean[];
-
   scaleTypes?: ScaleType[];
-
-  scaleUseRawDomains?: boolean[];
-
-  scaleZeros?: boolean[];
 
   // SPECIAL MODE
   /**
@@ -111,19 +101,16 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
   aggregates: [undefined, AggregateOp.MEAN],
   timeUnits: [undefined, TimeUnit.YEAR, TimeUnit.MONTH, TimeUnit.DAY, TimeUnit.DATE], // TODO: include hours and minutes
   types: [Type.NOMINAL, Type.ORDINAL, Type.QUANTITATIVE, Type.TEMPORAL],
-  numberOrdinalProportion: .05,
 
   maxBinsList: [5, 10, 20],
 
   scaleBandSizes: [17, 21],
-
   scaleDomains: [undefined],
-
+  scaleExponents: [1],
   scaleRanges: [undefined],
-
-  scaleExponents: [0.5, 1, 2],
-
   scaleTypes: [ScaleType.LINEAR, ScaleType.LOG],
+
+  numberOrdinalProportion: .05,
 
   // CONSTRAINTS
   // Spec Constraints -- See description inside src/constraints/spec.ts

--- a/src/model.ts
+++ b/src/model.ts
@@ -57,6 +57,9 @@ export interface EnumSpecIndex {
   /** List of indice tuple for encoding mappings that require enumerating scale.bandSize */
   scaleBandSize?: EnumSpecIndexTuple<number>[];
 
+  /** List of indice tuple for encoding mappings that require enumerating scale.clamp */
+  scaleClamp?: EnumSpecIndexTuple<boolean>[];
+
   /** List of indice tuple for encoding mappings that require enumerating scale.domain */
   scaleDomain?: EnumSpecIndexTuple<string | string[] | number[]>[];
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -57,6 +57,15 @@ export interface EnumSpecIndex {
   /** List of indice tuple for encoding mappings that require enumerating scale.bandSize */
   scaleBandSize?: EnumSpecIndexTuple<number>[];
 
+  /** List of indice tuple for encoding mappings that require enumerating scale.domain */
+  scaleDomain?: EnumSpecIndexTuple<string | string[] | number[]>[];
+
+  /** List of indice tuple for encoding mappings that require enumerating scale.exponent */
+  scaleExponent?: EnumSpecIndexTuple<number>[];
+
+  /** List of indice tuple for encoding mappings that require enumerating scale.range */
+  scaleRange?: EnumSpecIndexTuple<string | string[] | number[]>[];
+
   /** List of indice tuple for encoding mappings that require enumerating scale.type */
   scaleType?: EnumSpecIndexTuple<ScaleType>[];
 
@@ -93,8 +102,12 @@ export function getDefaultName(prop: Property) {
       return 's-bs';
     case Property.SCALE_CLAMP:
       return 's-c';
+    case Property.SCALE_DOMAIN:
+      return 's-d';
     case Property.SCALE_EXPONENT:
       return 's-e';
+    case Property.SCALE_RANGE:
+      return 's-ra';
     case Property.SCALE_ROUND:
       return 's-r';
     case Property.SCALE_TYPE:
@@ -121,6 +134,8 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
     case Property.BIN:
     case Property.SCALE:
     case Property.SCALE_CLAMP:
+    case Property.SCALE_DOMAIN:
+    case Property.SCALE_RANGE:
     case Property.SCALE_ROUND:
     case Property.SCALE_ZERO:
     case Property.AUTOCOUNT:
@@ -135,8 +150,14 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
     case Property.SCALE_BANDSIZE:
       return opt.scaleBandSizes;
 
+    case Property.SCALE_DOMAIN:
+      return opt.scaleDomains;
+
     case Property.SCALE_EXPONENT:
       return opt.scaleExponents;
+
+    case Property.SCALE_RANGE:
+      return opt.scaleRanges;
 
     case Property.SCALE_TYPE:
       return opt.scaleTypes;

--- a/src/model.ts
+++ b/src/model.ts
@@ -69,6 +69,9 @@ export interface EnumSpecIndex {
   /** List of indice tuple for encoding mappings that require enumerating scale.range */
   scaleRange?: EnumSpecIndexTuple<string | string[] | number[]>[];
 
+  /** List of indice tuple for encoding mappings that require enumerating scale.round */
+  scaleRound?: EnumSpecIndexTuple<boolean>[];
+
   /** List of indice tuple for encoding mappings that require enumerating scale.type */
   scaleType?: EnumSpecIndexTuple<ScaleType>[];
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -63,6 +63,9 @@ export interface EnumSpecIndex {
   /** List of indice tuple for encoding mappings that require enumerating scale.exponent */
   scaleExponent?: EnumSpecIndexTuple<number>[];
 
+  /** List of indice tuple for encoding mappings that require enumerating scale.nice */
+  scaleNice?: EnumSpecIndexTuple<boolean>[];
+
   /** List of indice tuple for encoding mappings that require enumerating scale.range */
   scaleRange?: EnumSpecIndexTuple<string | string[] | number[]>[];
 
@@ -106,6 +109,8 @@ export function getDefaultName(prop: Property) {
       return 's-d';
     case Property.SCALE_EXPONENT:
       return 's-e';
+    case Property.SCALE_NICE:
+      return 's-n';
     case Property.SCALE_RANGE:
       return 's-ra';
     case Property.SCALE_ROUND:
@@ -134,6 +139,7 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
     case Property.BIN:
     case Property.SCALE:
     case Property.SCALE_CLAMP:
+    case Property.SCALE_NICE:
     case Property.SCALE_ROUND:
     case Property.SCALE_ZERO:
     case Property.AUTOCOUNT:

--- a/src/model.ts
+++ b/src/model.ts
@@ -91,6 +91,10 @@ export function getDefaultName(prop: Property) {
       return 's';
     case Property.SCALE_BANDSIZE:
       return 'b-bs';
+    case Property.SCALE_CLAMP:
+      return 's-c';
+    case Property.SCALE_EXPONENT:
+      return 's-e';
     case Property.SCALE_ROUND:
       return 's-r';
     case Property.SCALE_TYPE:
@@ -116,6 +120,7 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
     // True, False for boolean values
     case Property.BIN:
     case Property.SCALE:
+    case Property.SCALE_CLAMP:
     case Property.SCALE_ROUND:
     case Property.SCALE_ZERO:
     case Property.AUTOCOUNT:
@@ -129,6 +134,9 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
 
     case Property.SCALE_BANDSIZE:
       return opt.scaleBandSizes;
+
+    case Property.SCALE_EXPONENT:
+      return opt.scaleExponents;
 
     case Property.SCALE_TYPE:
       return opt.scaleTypes;

--- a/src/model.ts
+++ b/src/model.ts
@@ -134,8 +134,6 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
     case Property.BIN:
     case Property.SCALE:
     case Property.SCALE_CLAMP:
-    case Property.SCALE_DOMAIN:
-    case Property.SCALE_RANGE:
     case Property.SCALE_ROUND:
     case Property.SCALE_ZERO:
     case Property.AUTOCOUNT:

--- a/src/model.ts
+++ b/src/model.ts
@@ -78,6 +78,9 @@ export interface EnumSpecIndex {
   /** List of indice tuple for encoding mappings that require enumerating scale.type */
   scaleType?: EnumSpecIndexTuple<ScaleType>[];
 
+  /** List of indice tuple for encoding mappings that require enumerating scale.useRawDomain */
+  scaleUseRawDomain?: EnumSpecIndexTuple<boolean>[];
+
   /** List of indice tuple for encoding mappings that require enumerating scale.zero */
   scaleZero?: EnumSpecIndexTuple<boolean>[];
 
@@ -123,6 +126,8 @@ export function getDefaultName(prop: Property) {
       return 's-r';
     case Property.SCALE_TYPE:
       return 's-t';
+    case Property.SCALE_USERAWDOMAIN:
+      return 's-u';
     case Property.SCALE_ZERO:
       return 's-z';
     case Property.TIMEUNIT:
@@ -147,6 +152,7 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
     case Property.SCALE_CLAMP:
     case Property.SCALE_NICE:
     case Property.SCALE_ROUND:
+    case Property.SCALE_USERAWDOMAIN:
     case Property.SCALE_ZERO:
     case Property.AUTOCOUNT:
       return [false, true];

--- a/src/model.ts
+++ b/src/model.ts
@@ -91,6 +91,8 @@ export function getDefaultName(prop: Property) {
       return 's';
     case Property.SCALE_BANDSIZE:
       return 'b-bs';
+    case Property.SCALE_ROUND:
+      return 's-r';
     case Property.SCALE_TYPE:
       return 's-t';
     case Property.SCALE_ZERO:
@@ -114,6 +116,7 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
     // True, False for boolean values
     case Property.BIN:
     case Property.SCALE:
+    case Property.SCALE_ROUND:
     case Property.SCALE_ZERO:
     case Property.AUTOCOUNT:
       return [false, true];

--- a/src/property.ts
+++ b/src/property.ts
@@ -21,6 +21,8 @@ export enum Property {
   // - Scale
   SCALE = 'scale' as any,
   SCALE_BANDSIZE = 'scaleBandSize' as any,
+  SCALE_CLAMP = 'scaleClamp' as any,
+  SCALE_EXPONENT = 'scaleExponent' as any,
   SCALE_ROUND = 'scaleRound' as any,
   SCALE_TYPE = 'scaleType' as any,
   SCALE_ZERO = 'scaleZero' as any,
@@ -50,6 +52,8 @@ export function hasNestedProperty(prop: Property) {
     case Property.TYPE:
     case Property.BIN_MAXBINS:
     case Property.SCALE_BANDSIZE:
+    case Property.SCALE_CLAMP:
+    case Property.SCALE_EXPONENT:
     case Property.SCALE_ROUND:
     case Property.SCALE_TYPE:
     case Property.SCALE_ZERO:
@@ -70,6 +74,8 @@ export const ENCODING_PROPERTIES = [
   Property.TYPE,
   Property.SCALE,
   Property.SCALE_BANDSIZE,
+  Property.SCALE_CLAMP,
+  Property.SCALE_EXPONENT,
   Property.SCALE_ROUND,
   Property.SCALE_TYPE,
   Property.SCALE_ZERO
@@ -96,9 +102,11 @@ export const DEFAULT_PROPERTY_PRECEDENCE: Property[] =  [
 
   // Nested Encoding Property
   Property.SCALE_BANDSIZE,
-  Property.SCALE_TYPE,
-  Property.SCALE_ZERO,
+  Property.SCALE_CLAMP,
+  Property.SCALE_EXPONENT,
   Property.SCALE_ROUND,
+  Property.SCALE_TYPE,
+  Property.SCALE_ZERO
 ];
 
 export interface NestedEncodingProperty {
@@ -119,6 +127,21 @@ export const NESTED_ENCODING_PROPERTIES: NestedEncodingProperty[] = [
     child: 'bandSize'
   },
   {
+    property: Property.SCALE_CLAMP,
+    parent: 'scale',
+    child: 'clamp'
+  },
+  {
+    property: Property.SCALE_EXPONENT,
+    parent: 'scale',
+    child: 'exponent'
+  },
+  {
+    property: Property.SCALE_ROUND,
+    parent: 'scale',
+    child: 'round'
+  },
+  {
     property: Property.SCALE_TYPE,
     parent: 'scale',
     child: 'type'
@@ -127,12 +150,8 @@ export const NESTED_ENCODING_PROPERTIES: NestedEncodingProperty[] = [
     property: Property.SCALE_ZERO,
     parent: 'scale',
     child: 'zero'
-  },
-  {
-    property: Property.SCALE_ROUND,
-    parent: 'scale',
-    child: 'round'
   }
+
   // TODO: other bin parameters
   // TODO: axis, legend
 ];

--- a/src/property.ts
+++ b/src/property.ts
@@ -21,6 +21,7 @@ export enum Property {
   // - Scale
   SCALE = 'scale' as any,
   SCALE_BANDSIZE = 'scaleBandSize' as any,
+  SCALE_ROUND = 'scaleRound' as any,
   SCALE_TYPE = 'scaleType' as any,
   SCALE_ZERO = 'scaleZero' as any,
 
@@ -49,6 +50,7 @@ export function hasNestedProperty(prop: Property) {
     case Property.TYPE:
     case Property.BIN_MAXBINS:
     case Property.SCALE_BANDSIZE:
+    case Property.SCALE_ROUND:
     case Property.SCALE_TYPE:
     case Property.SCALE_ZERO:
       return false;
@@ -68,6 +70,7 @@ export const ENCODING_PROPERTIES = [
   Property.TYPE,
   Property.SCALE,
   Property.SCALE_BANDSIZE,
+  Property.SCALE_ROUND,
   Property.SCALE_TYPE,
   Property.SCALE_ZERO
 ];
@@ -94,7 +97,8 @@ export const DEFAULT_PROPERTY_PRECEDENCE: Property[] =  [
   // Nested Encoding Property
   Property.SCALE_BANDSIZE,
   Property.SCALE_TYPE,
-  Property.SCALE_ZERO
+  Property.SCALE_ZERO,
+  Property.SCALE_ROUND,
 ];
 
 export interface NestedEncodingProperty {
@@ -123,6 +127,11 @@ export const NESTED_ENCODING_PROPERTIES: NestedEncodingProperty[] = [
     property: Property.SCALE_ZERO,
     parent: 'scale',
     child: 'zero'
+  },
+  {
+    property: Property.SCALE_ROUND,
+    parent: 'scale',
+    child: 'round'
   }
   // TODO: other bin parameters
   // TODO: axis, legend

--- a/src/property.ts
+++ b/src/property.ts
@@ -28,6 +28,7 @@ export enum Property {
   SCALE_RANGE = 'scaleRange' as any,
   SCALE_ROUND = 'scaleRound' as any,
   SCALE_TYPE = 'scaleType' as any,
+  SCALE_USERAWDOMAIN = 'scaleUseRawDomain' as any,
   SCALE_ZERO = 'scaleZero' as any,
 
 
@@ -62,6 +63,7 @@ export function hasNestedProperty(prop: Property) {
     case Property.SCALE_RANGE:
     case Property.SCALE_ROUND:
     case Property.SCALE_TYPE:
+    case Property.SCALE_USERAWDOMAIN:
     case Property.SCALE_ZERO:
       return false;
   }
@@ -87,6 +89,7 @@ export const ENCODING_PROPERTIES = [
   Property.SCALE_RANGE,
   Property.SCALE_ROUND,
   Property.SCALE_TYPE,
+  Property.SCALE_USERAWDOMAIN,
   Property.SCALE_ZERO
 ];
 
@@ -118,6 +121,7 @@ export const DEFAULT_PROPERTY_PRECEDENCE: Property[] =  [
   Property.SCALE_RANGE,
   Property.SCALE_ROUND,
   Property.SCALE_TYPE,
+  Property.SCALE_USERAWDOMAIN,
   Property.SCALE_ZERO
 ];
 
@@ -172,6 +176,11 @@ export const NESTED_ENCODING_PROPERTIES: NestedEncodingProperty[] = [
     property: Property.SCALE_TYPE,
     parent: 'scale',
     child: 'type'
+  },
+  {
+    property: Property.SCALE_USERAWDOMAIN,
+    parent: 'scale',
+    child: 'useRawDomain'
   },
   {
     property: Property.SCALE_ZERO,

--- a/src/property.ts
+++ b/src/property.ts
@@ -24,6 +24,7 @@ export enum Property {
   SCALE_CLAMP = 'scaleClamp' as any,
   SCALE_DOMAIN = 'scaleDomain' as any,
   SCALE_EXPONENT = 'scaleExponent' as any,
+  SCALE_NICE = 'scaleNice' as any,
   SCALE_RANGE = 'scaleRange' as any,
   SCALE_ROUND = 'scaleRound' as any,
   SCALE_TYPE = 'scaleType' as any,
@@ -57,6 +58,7 @@ export function hasNestedProperty(prop: Property) {
     case Property.SCALE_CLAMP:
     case Property.SCALE_DOMAIN:
     case Property.SCALE_EXPONENT:
+    case Property.SCALE_NICE:
     case Property.SCALE_RANGE:
     case Property.SCALE_ROUND:
     case Property.SCALE_TYPE:
@@ -81,6 +83,7 @@ export const ENCODING_PROPERTIES = [
   Property.SCALE_CLAMP,
   Property.SCALE_DOMAIN,
   Property.SCALE_EXPONENT,
+  Property.SCALE_NICE,
   Property.SCALE_RANGE,
   Property.SCALE_ROUND,
   Property.SCALE_TYPE,
@@ -111,6 +114,7 @@ export const DEFAULT_PROPERTY_PRECEDENCE: Property[] =  [
   Property.SCALE_CLAMP,
   Property.SCALE_DOMAIN,
   Property.SCALE_EXPONENT,
+  Property.SCALE_NICE,
   Property.SCALE_RANGE,
   Property.SCALE_ROUND,
   Property.SCALE_TYPE,
@@ -148,6 +152,11 @@ export const NESTED_ENCODING_PROPERTIES: NestedEncodingProperty[] = [
     property: Property.SCALE_EXPONENT,
     parent: 'scale',
     child: 'exponent'
+  },
+  {
+    property: Property.SCALE_NICE,
+    parent: 'scale',
+    child: 'nice'
   },
   {
     property: Property.SCALE_RANGE,

--- a/src/property.ts
+++ b/src/property.ts
@@ -22,7 +22,9 @@ export enum Property {
   SCALE = 'scale' as any,
   SCALE_BANDSIZE = 'scaleBandSize' as any,
   SCALE_CLAMP = 'scaleClamp' as any,
+  SCALE_DOMAIN = 'scaleDomain' as any,
   SCALE_EXPONENT = 'scaleExponent' as any,
+  SCALE_RANGE = 'scaleRange' as any,
   SCALE_ROUND = 'scaleRound' as any,
   SCALE_TYPE = 'scaleType' as any,
   SCALE_ZERO = 'scaleZero' as any,
@@ -53,7 +55,9 @@ export function hasNestedProperty(prop: Property) {
     case Property.BIN_MAXBINS:
     case Property.SCALE_BANDSIZE:
     case Property.SCALE_CLAMP:
+    case Property.SCALE_DOMAIN:
     case Property.SCALE_EXPONENT:
+    case Property.SCALE_RANGE:
     case Property.SCALE_ROUND:
     case Property.SCALE_TYPE:
     case Property.SCALE_ZERO:
@@ -75,7 +79,9 @@ export const ENCODING_PROPERTIES = [
   Property.SCALE,
   Property.SCALE_BANDSIZE,
   Property.SCALE_CLAMP,
+  Property.SCALE_DOMAIN,
   Property.SCALE_EXPONENT,
+  Property.SCALE_RANGE,
   Property.SCALE_ROUND,
   Property.SCALE_TYPE,
   Property.SCALE_ZERO
@@ -103,7 +109,9 @@ export const DEFAULT_PROPERTY_PRECEDENCE: Property[] =  [
   // Nested Encoding Property
   Property.SCALE_BANDSIZE,
   Property.SCALE_CLAMP,
+  Property.SCALE_DOMAIN,
   Property.SCALE_EXPONENT,
+  Property.SCALE_RANGE,
   Property.SCALE_ROUND,
   Property.SCALE_TYPE,
   Property.SCALE_ZERO
@@ -132,9 +140,19 @@ export const NESTED_ENCODING_PROPERTIES: NestedEncodingProperty[] = [
     child: 'clamp'
   },
   {
+    property: Property.SCALE_DOMAIN,
+    parent: 'scale',
+    child: 'domain'
+  },
+  {
     property: Property.SCALE_EXPONENT,
     parent: 'scale',
     child: 'exponent'
+  },
+  {
+    property: Property.SCALE_RANGE,
+    parent: 'scale',
+    child: 'range'
   },
   {
     property: Property.SCALE_ROUND,

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -35,7 +35,9 @@ export interface BinQuery extends EnumSpec<boolean> {
 export interface ScaleQuery extends EnumSpec<boolean> {
   // TODO: add other properties from vegalite/src/scale
   clamp?: boolean | EnumSpec<boolean> | ShortEnumSpec;
+  domain?: string | number[] | string[] | EnumSpec<string | number[] | string[]> | ShortEnumSpec;
   exponent?: number | EnumSpec<number> | ShortEnumSpec;
+  range?: string | number[] | string[] | EnumSpec<string | number[] | string[]> | ShortEnumSpec;
   round?: boolean | EnumSpec<boolean> | ShortEnumSpec;
   type?: ScaleType | EnumSpec<ScaleType> | ShortEnumSpec;
   zero?: boolean | EnumSpec<boolean> | ShortEnumSpec;

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -35,7 +35,7 @@ export interface BinQuery extends EnumSpec<boolean> {
 export interface ScaleQuery extends EnumSpec<boolean> {
   // TODO: add other properties from vegalite/src/scale
   clamp?: boolean | EnumSpec<boolean> | ShortEnumSpec;
-  domain?: string | number[] | string[] | EnumSpec<string | number[] | string[]> | ShortEnumSpec;
+  domain?: number[] | string[] | EnumSpec<number[] | string[]> | ShortEnumSpec;
   exponent?: number | EnumSpec<number> | ShortEnumSpec;
   nice?: boolean | EnumSpec<boolean> | ShortEnumSpec;
   range?: string | number[] | string[] | EnumSpec<string | number[] | string[]> | ShortEnumSpec;

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -41,6 +41,7 @@ export interface ScaleQuery extends EnumSpec<boolean> {
   range?: string | number[] | string[] | EnumSpec<string | number[] | string[]> | ShortEnumSpec;
   round?: boolean | EnumSpec<boolean> | ShortEnumSpec;
   type?: ScaleType | EnumSpec<ScaleType> | ShortEnumSpec;
+  useRawDomain?: boolean | EnumSpec<boolean> | ShortEnumSpec;
   zero?: boolean | EnumSpec<boolean> | ShortEnumSpec;
 
 }

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -34,9 +34,12 @@ export interface BinQuery extends EnumSpec<boolean> {
 
 export interface ScaleQuery extends EnumSpec<boolean> {
   // TODO: add other properties from vegalite/src/scale
+  clamp?: boolean | EnumSpec<boolean> | ShortEnumSpec;
+  exponent?: number | EnumSpec<number> | ShortEnumSpec;
   round?: boolean | EnumSpec<boolean> | ShortEnumSpec;
   type?: ScaleType | EnumSpec<ScaleType> | ShortEnumSpec;
   zero?: boolean | EnumSpec<boolean> | ShortEnumSpec;
+
 }
 
 export function isDimension(encQ: EncodingQuery) {

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -37,6 +37,7 @@ export interface ScaleQuery extends EnumSpec<boolean> {
   clamp?: boolean | EnumSpec<boolean> | ShortEnumSpec;
   domain?: string | number[] | string[] | EnumSpec<string | number[] | string[]> | ShortEnumSpec;
   exponent?: number | EnumSpec<number> | ShortEnumSpec;
+  nice?: boolean | EnumSpec<boolean> | ShortEnumSpec;
   range?: string | number[] | string[] | EnumSpec<string | number[] | string[]> | ShortEnumSpec;
   round?: boolean | EnumSpec<boolean> | ShortEnumSpec;
   type?: ScaleType | EnumSpec<ScaleType> | ShortEnumSpec;

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -34,6 +34,7 @@ export interface BinQuery extends EnumSpec<boolean> {
 
 export interface ScaleQuery extends EnumSpec<boolean> {
   // TODO: add other properties from vegalite/src/scale
+  round?: boolean | EnumSpec<boolean> | ShortEnumSpec;
   type?: ScaleType | EnumSpec<ScaleType> | ShortEnumSpec;
   zero?: boolean | EnumSpec<boolean> | ShortEnumSpec;
 }

--- a/test/enumerator.test.ts
+++ b/test/enumerator.test.ts
@@ -282,6 +282,54 @@ describe('enumerator', () => {
       });
     });
 
+    describe('scaleDomain', () => {
+      it('should correctly enumerate scaleDomain with string[] values', () => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {
+              channel: Channel.X,
+              scale: {
+                domain: {values: [undefined, ['cats', 'dogs'], ['chickens', 'pigs']]}
+              },
+              field: 'N',
+              type: Type.NOMINAL
+            }
+          ]
+        });
+        const enumerator = ENUMERATOR_INDEX[Property.SCALE_DOMAIN](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
+
+        const answerSet = enumerator([], specM);
+        assert.equal(answerSet.length, 3);
+        assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).domain, undefined);
+        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).domain, ['cats', 'dogs']);
+        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).domain, ['chickens', 'pigs']);
+      });
+
+      it('should correctly enumerate scaleDomain with number[] values', () => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {
+              channel: Channel.X,
+              scale: {
+                domain: {values: [undefined, [1,3], [5,7]]}
+              },
+              field: 'Q',
+              type: Type.QUANTITATIVE
+            }
+          ]
+        });
+        const enumerator = ENUMERATOR_INDEX[Property.SCALE_DOMAIN](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
+
+        const answerSet = enumerator([], specM);
+        assert.equal(answerSet.length, 3);
+        assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).domain, undefined);
+        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).domain, [1,3]);
+        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).domain, [5,7]);
+      });
+    });
+
     describe('scaleExponent', () => {
       it('should correctly enumerate scaleExponent', () => {
         const specM = buildSpecQueryModel({
@@ -304,6 +352,54 @@ describe('enumerator', () => {
         assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).exponent, 0.5);
         assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).exponent, 1);
         assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).exponent, 2);
+      });
+    });
+
+    describe('scaleRange', () => {
+      it('should correctly enumerate scaleRange with string[] values', () => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {
+              channel: Channel.X,
+              scale: {
+                range: {values: [undefined, ['cats', 'dogs'], ['chickens', 'pigs']]}
+              },
+              field: 'N',
+              type: Type.NOMINAL
+            }
+          ]
+        });
+        const enumerator = ENUMERATOR_INDEX[Property.SCALE_RANGE](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
+
+        const answerSet = enumerator([], specM);
+        assert.equal(answerSet.length, 3);
+        assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).range, undefined);
+        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).range, ['cats', 'dogs']);
+        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).range, ['chickens', 'pigs']);
+      });
+
+      it('should correctly enumerate scaleRange with number[] values', () => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {
+              channel: Channel.X,
+              scale: {
+                range: {values: [undefined, [1,3], [5,7]]}
+              },
+              field: 'Q',
+              type: Type.QUANTITATIVE
+            }
+          ]
+        });
+        const enumerator = ENUMERATOR_INDEX[Property.SCALE_RANGE](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
+
+        const answerSet = enumerator([], specM);
+        assert.equal(answerSet.length, 3);
+        assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).range, undefined);
+        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).range, [1,3]);
+        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).range, [5,7]);
       });
     });
 

--- a/test/enumerator.test.ts
+++ b/test/enumerator.test.ts
@@ -355,6 +355,28 @@ describe('enumerator', () => {
       });
     });
 
+    describe('scaleNice', () => {
+      it('should correctly enumerate scaleNice', () => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {
+              channel: Channel.X,
+              scale: {
+                nice: {values: [undefined, true, false]}
+              },
+              field: 'Q',
+              type: Type.QUANTITATIVE
+            }
+          ]
+        });
+        const enumerator = ENUMERATOR_INDEX[Property.SCALE_NICE](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
+
+        const answerSet = enumerator([], specM);
+        assert.equal(answerSet.length, 3);
+      });
+    });
+
     describe('scaleRange', () => {
       it('should correctly enumerate scaleRange with string[] values', () => {
         const specM = buildSpecQueryModel({

--- a/test/enumerator.test.ts
+++ b/test/enumerator.test.ts
@@ -266,7 +266,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                clamp: {values: [true, false]}
+                clamp: {values: [true, false, undefined]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -276,9 +276,10 @@ describe('enumerator', () => {
         const enumerator = ENUMERATOR_INDEX[Property.SCALE_CLAMP](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
 
         const answerSet = enumerator([], specM);
-        assert.equal(answerSet.length, 2);
+        assert.equal(answerSet.length, 3);
         assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).clamp, true);
         assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).clamp, false);
+        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).clamp, undefined);
       });
     });
 

--- a/test/enumerator.test.ts
+++ b/test/enumerator.test.ts
@@ -258,28 +258,52 @@ describe('enumerator', () => {
       });
     });
 
-    describe('scaleType', () => {
-      it('should correctly enumerate scaleType', () => {
+    describe('scaleClamp', () => {
+      it('should correctly enumerate scaleClamp', () => {
         const specM = buildSpecQueryModel({
           mark: Mark.POINT,
           encodings: [
             {
               channel: Channel.X,
               scale: {
-                type: {values: [undefined, ScaleType.LOG, ScaleType.POW, ScaleType.ORDINAL]}
+                clamp: {values: [true, false]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
             }
           ]
         });
-        const enumerator = ENUMERATOR_INDEX[Property.SCALE_TYPE](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
+        const enumerator = ENUMERATOR_INDEX[Property.SCALE_CLAMP](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
+
+        const answerSet = enumerator([], specM);
+        assert.equal(answerSet.length, 2);
+        assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).clamp, true);
+        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).clamp, false);
+      });
+    });
+
+    describe('scaleExponent', () => {
+      it('should correctly enumerate scaleExponent', () => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {
+              channel: Channel.X,
+              scale: {
+                exponent: {values: [0.5, 1, 2]}
+              },
+              field: 'Q',
+              type: Type.QUANTITATIVE
+            }
+          ]
+        });
+        const enumerator = ENUMERATOR_INDEX[Property.SCALE_EXPONENT](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
 
         const answerSet = enumerator([], specM);
         assert.equal(answerSet.length, 3);
-        assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).type, undefined);
-        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).type, ScaleType.LOG);
-        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).type, ScaleType.POW);
+        assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).exponent, 0.5);
+        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).exponent, 1);
+        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).exponent, 2);
       });
     });
 
@@ -304,6 +328,31 @@ describe('enumerator', () => {
         assert.equal(answerSet.length, 2);
         assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).round, true);
         assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).round, false);
+      });
+    });
+
+    describe('scaleType', () => {
+      it('should correctly enumerate scaleType', () => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {
+              channel: Channel.X,
+              scale: {
+                type: {values: [undefined, ScaleType.LOG, ScaleType.POW, ScaleType.ORDINAL]}
+              },
+              field: 'Q',
+              type: Type.QUANTITATIVE
+            }
+          ]
+        });
+        const enumerator = ENUMERATOR_INDEX[Property.SCALE_TYPE](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
+
+        const answerSet = enumerator([], specM);
+        assert.equal(answerSet.length, 3);
+        assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).type, undefined);
+        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).type, ScaleType.LOG);
+        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).type, ScaleType.POW);
       });
     });
 

--- a/test/enumerator.test.ts
+++ b/test/enumerator.test.ts
@@ -433,7 +433,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                round: {values: [true, false]}
+                round: {values: [true, false, undefined]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -443,9 +443,10 @@ describe('enumerator', () => {
         const enumerator = ENUMERATOR_INDEX[Property.SCALE_ROUND](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
 
         const answerSet = enumerator([], specM);
-        assert.equal(answerSet.length, 2);
+        assert.equal(answerSet.length, 3);
         assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).round, true);
         assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).round, false);
+        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).round, undefined);
       });
     });
 
@@ -471,6 +472,31 @@ describe('enumerator', () => {
         assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).type, undefined);
         assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).type, ScaleType.LOG);
         assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).type, ScaleType.POW);
+      });
+    });
+
+    describe('scaleUseRawDomain', () => {
+      it('should correctly enumerate scaleUseRawDomain', () => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {
+              channel: Channel.X,
+              scale: {
+                useRawDomain: {values: [true, false, undefined]}
+              },
+              field: 'Q',
+              type: Type.QUANTITATIVE
+            }
+          ]
+        });
+        const enumerator = ENUMERATOR_INDEX[Property.SCALE_USERAWDOMAIN](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
+
+        const answerSet = enumerator([], specM);
+        assert.equal(answerSet.length, 3);
+        assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).useRawDomain, true);
+        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).useRawDomain, false);
+        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).useRawDomain, undefined);
       });
     });
 

--- a/test/enumerator.test.ts
+++ b/test/enumerator.test.ts
@@ -339,7 +339,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                exponent: {values: [0.5, 1, 2]}
+                exponent: {values: [0.5, 1, 2, undefined]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -349,10 +349,12 @@ describe('enumerator', () => {
         const enumerator = ENUMERATOR_INDEX[Property.SCALE_EXPONENT](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
 
         const answerSet = enumerator([], specM);
-        assert.equal(answerSet.length, 3);
+        assert.equal(answerSet.length, 4);
         assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).exponent, 0.5);
         assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).exponent, 1);
         assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).exponent, 2);
+        assert.deepEqual((answerSet[3].getEncodingQueryByIndex(0).scale as ScaleQuery).exponent, undefined);
+
       });
     });
 

--- a/test/enumerator.test.ts
+++ b/test/enumerator.test.ts
@@ -283,6 +283,30 @@ describe('enumerator', () => {
       });
     });
 
+    describe('scaleRound', () => {
+      it('should correctly enumerate scaleRound', () => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {
+              channel: Channel.X,
+              scale: {
+                round: {values: [true, false]}
+              },
+              field: 'Q',
+              type: Type.QUANTITATIVE
+            }
+          ]
+        });
+        const enumerator = ENUMERATOR_INDEX[Property.SCALE_ROUND](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
+
+        const answerSet = enumerator([], specM);
+        assert.equal(answerSet.length, 2);
+        assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).round, true);
+        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).round, false);
+      });
+    });
+
     describe('timeUnit', () => {
       it('should correctly enumerate timeUnits', () => {
         const specM = buildSpecQueryModel({

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -7,9 +7,14 @@ import {Type} from 'vega-lite/src/type';
 
 import {DEFAULT_QUERY_CONFIG} from '../src/config';
 import {SpecQueryModel, getDefaultName, getDefaultEnumValues} from '../src/model';
+<<<<<<< HEAD
 import {Property, DEFAULT_PROPERTY_PRECEDENCE, ENCODING_PROPERTIES, NESTED_ENCODING_PROPERTIES} from '../src/property';
 import {SHORT_ENUM_SPEC, isEnumSpec} from '../src/enumspec';
 import {SpecQuery} from '../src/query/spec';
+=======
+import {DEFAULT_PROPERTY_PRECEDENCE, Property, ENCODING_PROPERTIES, NESTED_ENCODING_PROPERTIES} from '../src/property';
+import {SHORT_ENUM_SPEC, SpecQuery, isEnumSpec} from '../src/query';
+>>>>>>> basic support for scale.round
 import {Schema} from '../src/schema';
 import {duplicate, extend} from '../src/util';
 

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -7,14 +7,9 @@ import {Type} from 'vega-lite/src/type';
 
 import {DEFAULT_QUERY_CONFIG} from '../src/config';
 import {SpecQueryModel, getDefaultName, getDefaultEnumValues} from '../src/model';
-<<<<<<< HEAD
 import {Property, DEFAULT_PROPERTY_PRECEDENCE, ENCODING_PROPERTIES, NESTED_ENCODING_PROPERTIES} from '../src/property';
 import {SHORT_ENUM_SPEC, isEnumSpec} from '../src/enumspec';
 import {SpecQuery} from '../src/query/spec';
-=======
-import {DEFAULT_PROPERTY_PRECEDENCE, Property, ENCODING_PROPERTIES, NESTED_ENCODING_PROPERTIES} from '../src/property';
-import {SHORT_ENUM_SPEC, SpecQuery, isEnumSpec} from '../src/query';
->>>>>>> basic support for scale.round
 import {Schema} from '../src/schema';
 import {duplicate, extend} from '../src/util';
 

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -136,6 +136,14 @@ describe('query/shorthand', () => {
       assert.equal(str, 'a,q,scale={"zero":true}');
     });
 
+    // FELIX -- REBASE COMMENT
+    it('should return correct fieldDef string for scale with round=true', () => {
+      const str = fieldDefShorthand({
+        channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {round: true}
+      });
+      assert.equal(str, 'a,q,scale={"round":true}');
+    });
+
     // TODO: Update tests for other scale.*
 
     it('should return correct fieldDefShorthand string for ambiguous bin field', () => {

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -143,6 +143,34 @@ describe('query/shorthand', () => {
       assert.equal(str, '?(a,q)');
     });
 
+    it('should return correct fieldDefShorthand string for scale with a string[] domain', () => {
+      const str = fieldDefShorthand({
+        channel: Channel.X, field: 'a', type: Type.NOMINAL, scale: {domain: ['cats', 'dogs']}
+      });
+      assert.equal(str, 'a,n,scale={"domain":["cats","dogs"]}');
+    });
+
+    it('should return correct fieldDefShorthand string for scale with a number[] domain', () => {
+      const str = fieldDefShorthand({
+        channel: Channel.X, field: 'a', type: Type.NOMINAL, scale: {domain: [1,2]}
+      });
+      assert.equal(str, 'a,n,scale={"domain":[1,2]}');
+    });
+
+    it('should return correct fieldDefShorthand string for scale with a string[] range', () => {
+      const str = fieldDefShorthand({
+        channel: Channel.X, field: 'a', type: Type.NOMINAL, scale: {range: ['cats', 'dogs']}
+      });
+      assert.equal(str, 'a,n,scale={"range":["cats","dogs"]}');
+    });
+
+    it('should return correct fieldDefShorthand string for scale with a number[] range', () => {
+      const str = fieldDefShorthand({
+        channel: Channel.X, field: 'a', type: Type.NOMINAL, scale: {range: [1,2]}
+      });
+      assert.equal(str, 'a,n,scale={"range":[1,2]}');
+    });
+
     it('should return correct fieldDefShorthand string for bin field', () => {
        const str = fieldDefShorthand({
          channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, bin: true

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -235,6 +235,13 @@ describe('query/shorthand', () => {
       assert.equal(str, 'a,q,scale={"clamp":true}');
     });
 
+    it('should return correct fieldDef string for scale with round=true', () => {
+      const str = fieldDefShorthand({
+        channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {round: true}
+      });
+      assert.equal(str, 'a,q,scale={"round":true}');
+    });
+
     it('should return correct fieldDef string for scale with exponent of 3 and supported scaleType', () => {
        const str = fieldDefShorthand({
          channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {type: ScaleType.POW, exponent: 3}

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -129,19 +129,32 @@ describe('query/shorthand', () => {
        assert.equal(str, 'a,q,scale={"type":"log"}');
     });
 
-    it('should return correct fieldDefShorthand string for scale with zero=true', () => {
+    it('should return correct fieldDef string for scale with clamp=true', () => {
       const str = fieldDefShorthand({
-        channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {zero: true}
+        channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {clamp: true}
       });
-      assert.equal(str, 'a,q,scale={"zero":true}');
+      assert.equal(str, 'a,q,scale={"clamp":true}');
     });
 
-    // FELIX -- REBASE COMMENT
+    it('should return correct fieldDef string for scale with exponent of 3 and supported scaleType', () => {
+       const str = fieldDefShorthand({
+         channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {type: ScaleType.POW, exponent: 3}
+       });
+       assert.equal(str, 'a,q,scale={"exponent":3,"type":"pow"}');
+    });
+
     it('should return correct fieldDef string for scale with round=true', () => {
       const str = fieldDefShorthand({
         channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {round: true}
       });
       assert.equal(str, 'a,q,scale={"round":true}');
+    });
+
+    it('should return correct fieldDef string for scale with zero=true', () => {
+      const str = fieldDefShorthand({
+        channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {zero: true}
+      });
+      assert.equal(str, 'a,q,scale={"zero":true}');
     });
 
     // TODO: Update tests for other scale.*

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -242,6 +242,13 @@ describe('query/shorthand', () => {
        assert.equal(str, 'a,q,scale={"exponent":3,"type":"pow"}');
     });
 
+    it('should return correct fieldDef string for scale with nice=true', () => {
+      const str = fieldDefShorthand({
+        channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {nice: true}
+      });
+      assert.equal(str, 'a,q,scale={"nice":true}');
+    });
+
     it('should return correct fieldDef string for scale with round=true', () => {
       const str = fieldDefShorthand({
         channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {round: true}


### PR DESCRIPTION
Fix #2. 
Add test and basic support for scale.clamp, scale.domain, scale.exponent, scale.range, scale.round
