### PR TITLE
Fix #155 Order the FieldSchemas

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -54,6 +54,20 @@ export class Schema {
       };
     });
 
+    // order the fieldSchemas (sort them)
+    const order = [Type.NOMINAL, Type.TEMPORAL, Type.QUANTITATIVE, Type.ORDINAL];
+    fieldSchemas.sort(function(a: FieldSchema, b: FieldSchema) {
+      // first order by type: nominal < temporal < quantitative < ordinal
+      if (order.indexOf(a.type) < order.indexOf(b.type)) {
+        return -1;
+      } else if (order.indexOf(a.type) > order.indexOf(b.type)) {
+        return 1;
+      } else {
+        // then order by field (alphabetically)
+        return a.field.localeCompare(b.field);
+      }
+    });
+
     let schema = new Schema(fieldSchemas);
 
     // calculate preset bins

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -55,12 +55,17 @@ export class Schema {
     });
 
     // order the fieldSchemas (sort them)
-    const order = [Type.NOMINAL, Type.TEMPORAL, Type.QUANTITATIVE, Type.ORDINAL];
+    const order = {
+      'nominal': 0,
+      'ordinal': 1,
+      'temporal': 2,
+      'quantitative': 3
+    };
     fieldSchemas.sort(function(a: FieldSchema, b: FieldSchema) {
       // first order by type: nominal < temporal < quantitative < ordinal
-      if (order.indexOf(a.type) < order.indexOf(b.type)) {
+      if (order[a.type] < order[b.type]) {
         return -1;
-      } else if (order.indexOf(a.type) > order.indexOf(b.type)) {
+      } else if (order[a.type] > order[b.type]) {
         return 1;
       } else {
         // then order by field (alphabetically)

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -16,6 +16,18 @@ describe('schema', () => {
       assert.isNotNull(schema);
       assert.equal(schema.fields().length, 0);
     });
+
+    it('should store FieldSchemas in the correct order', () => {
+      const data = [
+        {a: '1/1/2000', c: 'abc', d: 1, b: 1}
+      ];
+      var schema = Schema.build(data);
+
+      assert.equal(schema['fieldSchemas'][0]['field'], 'c');
+      assert.equal(schema['fieldSchemas'][1]['field'], 'a');
+      assert.equal(schema['fieldSchemas'][2]['field'], 'b');
+      assert.equal(schema['fieldSchemas'][3]['field'], 'd');
+    });
   });
 
   const data = [


### PR DESCRIPTION
Orders FieldSchemas in the following order:
1. By type. nominal < temporal < quantitative < ordinal
2. By field name, alphabetically

This should mean that when fields are enumerated, they should be presented in a more intuitive manner (issue #155).