### PR TITLE
Correct isEnumSpec method, which causes `fo/scale_round` to fail

### DIFF
--- a/src/enumspec.ts
+++ b/src/enumspec.ts
@@ -1,4 +1,4 @@
-import {extend} from './util';
+import {extend, isArray} from './util';
 
 
 /** Enum for a short form of the enumeration spec. */
@@ -14,7 +14,7 @@ export interface EnumSpec<T> {
 }
 
 export function isEnumSpec(prop: any) {
-  return prop === SHORT_ENUM_SPEC || (prop !== undefined && !!prop.values);
+  return prop === SHORT_ENUM_SPEC || (prop !== undefined && (!!prop.values || !!prop.name) && !isArray(prop));
 }
 
 export function initEnumSpec(prop: any, defaultName: string, defaultEnumValues: any[]): EnumSpec<any> & any {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import {isArray} from 'datalib/src/util';
-export {keys, duplicate, extend} from 'datalib/src/util';
+export {keys, duplicate, extend, isObject, isArray} from 'datalib/src/util';
 
 export interface Dict<T> {
   [key: string]: T;

--- a/test/enumspec.test.ts
+++ b/test/enumspec.test.ts
@@ -1,7 +1,48 @@
 import {assert} from 'chai';
-import {initEnumSpec} from '../src/enumspec';
+import {initEnumSpec, isEnumSpec, SHORT_ENUM_SPEC} from '../src/enumspec';
 
 describe('enumspec', () => {
+  describe('isEnumSpec', () => {
+    it('should return true for an enum spec with name and values', () => {
+      assert(isEnumSpec({
+        name: 'a',
+        values: [1,2,3]
+      }));
+    });
+
+    it('should return true for an enum spec with name.', () => {
+      assert(isEnumSpec({
+        name: 'a'
+      }));
+    });
+
+    it('should return true for an enum spec with values', () => {
+      assert(isEnumSpec({
+        values: [1,2,3]
+      }));
+    });
+
+    it('should return true for a short enum spec', () => {
+      assert(isEnumSpec(SHORT_ENUM_SPEC));
+    });
+
+    it('should return false for a string', () => {
+      assert(!isEnumSpec('string'));
+    });
+
+    it('should return false for a number', () => {
+      assert(!isEnumSpec(9));
+    });
+
+    it('should return false for a boolean value', () => {
+      assert(!isEnumSpec(true));
+    });
+
+    it('should return false for an array', () => {
+      assert(!isEnumSpec([1,2]));
+    });
+  });
+
   describe('initEnumSpec', () => {
     it('should return full enumSpec with other properties preserved', () => {
       const binQuery = initEnumSpec({values: [true, false], maxbins: 30}, 'b1', [true, false]);


### PR DESCRIPTION
cc: @felixcodes 