### PR TITLE
Restructure enumSpecIndex for encodings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compassql",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "CompassQL visualization query language",
   "main": "compassql.js",
   "directories": {

--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -1,16 +1,17 @@
 import {Channel, getSupportedRole} from 'vega-lite/src/channel';
+import {ScaleType} from 'vega-lite/src/scale';
 import {Type} from 'vega-lite/src/type';
 
+import {AbstractConstraint, AbstractConstraintModel} from './base';
+
 import {QueryConfig} from '../config';
-import {EnumSpecIndexTuple, SpecQueryModel} from '../model';
+import {SpecQueryModel} from '../model';
 import {getNestedEncodingProperty, Property} from '../property';
-import {scaleType, EncodingQuery, isDimension, isMeasure, ScaleQuery} from '../query/encoding';
-import {isEnumSpec} from '../enumspec';
+import {isEnumSpec, EnumSpec} from '../enumspec';
 import {PrimitiveType, Schema} from '../schema';
 import {contains, every} from '../util';
-import {ScaleType} from 'vega-lite/src/scale';
 
-import {AbstractConstraint, AbstractConstraintModel} from './base';
+import {scaleType, EncodingQuery, isDimension, isMeasure, ScaleQuery} from '../query/encoding';
 
 /**
  * Collection of constraints for a single encoding mapping.
@@ -263,12 +264,12 @@ export const ENCODING_CONSTRAINTS_BY_PROPERTY: {[prop: string]: EncodingConstrai
 /**
  * Check all encoding constraints for a particular property and index tuple
  */
-export function checkEncoding(prop: Property, indexTuple: EnumSpecIndexTuple<any>,
+export function checkEncoding(prop: Property, enumSpec: EnumSpec<any>, index: number,
   specM: SpecQueryModel, schema: Schema, opt: QueryConfig): string {
 
   // Check encoding constraint
   const encodingConstraints = ENCODING_CONSTRAINTS_BY_PROPERTY[prop] || [];
-  const encQ = specM.getEncodingQueryByIndex(indexTuple.index);
+  const encQ = specM.getEncodingQueryByIndex(index);
 
   for (let i = 0; i < encodingConstraints.length; i++) {
     const c = encodingConstraints[i];
@@ -281,7 +282,7 @@ export function checkEncoding(prop: Property, indexTuple: EnumSpecIndexTuple<any
         let violatedConstraint = '(enc) ' + c.name();
         /* istanbul ignore if */
         if (opt.verbose) {
-          console.log(violatedConstraint + ' failed with ' + specM.toShorthand() + ' for ' + indexTuple.enumSpec.name);
+          console.log(violatedConstraint + ' failed with ' + specM.toShorthand() + ' for ' + enumSpec.name);
         }
         return violatedConstraint;
       }

--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -7,12 +7,13 @@ import {Type} from 'vega-lite/src/type';
 import {AbstractConstraint, AbstractConstraintModel} from './base';
 
 import {QueryConfig} from '../config';
-import {SpecQueryModel, EnumSpecIndexTuple} from '../model';
+import {isEnumSpec, EnumSpec} from '../enumspec';
+import {SpecQueryModel} from '../model';
 import {getNestedEncodingProperty, Property, isEncodingProperty} from '../property';
 import {Schema} from '../schema';
-import {isEnumSpec} from '../enumspec';
-import {scaleType, EncodingQuery, isMeasure, ScaleQuery} from '../query/encoding';
 import {contains, every, some} from '../util';
+
+import {scaleType, EncodingQuery, isMeasure, ScaleQuery} from '../query/encoding';
 
 export interface SpecConstraintChecker {
   (specM: SpecQueryModel, schema: Schema, opt: QueryConfig): boolean;
@@ -171,8 +172,8 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
           throw new Error('Unsupported Type');
         });
       } else {
-        const neverHaveAutoCount = every(specM.enumSpecIndex.autoCount, (indexTuple: EnumSpecIndexTuple<boolean>) => {
-          return !isEnumSpec(specM.getEncodingQueryByIndex(indexTuple.index).autoCount);
+        const neverHaveAutoCount = every(specM.enumSpecIndex.encodingIndicesByProperty['autoCount'], (index: number) => {
+          return !isEnumSpec(specM.getEncodingQueryByIndex(index).autoCount);
         });
         if (neverHaveAutoCount) {
           // If the query surely does not have autoCount
@@ -582,7 +583,7 @@ export const SPEC_CONSTRAINTS_BY_PROPERTY: {[prop: string]: SpecConstraintModel[
 /**
  * Check all encoding constraints for a particular property and index tuple
  */
-export function checkSpec(prop: Property, indexTuple: EnumSpecIndexTuple<any>,
+export function checkSpec(prop: Property, enumSpec: EnumSpec<any>,
   specM: SpecQueryModel, schema: Schema, opt: QueryConfig): string {
 
   // Check encoding constraint
@@ -599,7 +600,7 @@ export function checkSpec(prop: Property, indexTuple: EnumSpecIndexTuple<any>,
         let violatedConstraint = '(spec) ' + c.name();
         /* istanbul ignore if */
         if (opt.verbose) {
-          console.log(violatedConstraint + ' failed with ' + specM.toShorthand() + ' for ' + indexTuple.enumSpec.name);
+          console.log(violatedConstraint + ' failed with ' + specM.toShorthand() + ' for ' + enumSpec.name);
         }
         return violatedConstraint;
       }

--- a/src/enumspec.ts
+++ b/src/enumspec.ts
@@ -13,11 +13,15 @@ export interface EnumSpec<T> {
   values?: T[];
 }
 
+export interface ExtendedEnumSpec<T> extends EnumSpec<T> {
+  [prop: string]: any;
+}
+
 export function isEnumSpec(prop: any) {
   return prop === SHORT_ENUM_SPEC || (prop !== undefined && (!!prop.values || !!prop.name) && !isArray(prop));
 }
 
-export function initEnumSpec(prop: any, defaultName: string, defaultEnumValues: any[]): EnumSpec<any> & any {
+export function initEnumSpec(prop: any, defaultName: string, defaultEnumValues: any[]): ExtendedEnumSpec<any> {
   return extend({}, {
       name: defaultName,
       values: defaultEnumValues

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,7 +1,7 @@
 import {ENUMERATOR_INDEX} from '../src/enumerator';
 
 import {QueryConfig, DEFAULT_QUERY_CONFIG} from './config';
-import {SpecQueryModel} from './model';
+import {SpecQueryModel, hasPropertyIndex} from './model';
 import {SpecQuery} from './query/spec';
 import {Schema} from './schema';
 
@@ -15,7 +15,7 @@ export function generate(specQ: SpecQuery, schema: Schema, opt: QueryConfig = DE
   let answerSet = [specM]; // Initialize Answer Set with only the input spec query.
   opt.propertyPrecedence.forEach((prop) => {
     // If the original specQuery contains enumSpec for this prop type
-    if (enumSpecIndex[prop]) {
+    if (hasPropertyIndex(enumSpecIndex, prop)) {
       // update answerset
       const reducer = ENUMERATOR_INDEX[prop](enumSpecIndex, schema, opt);
       answerSet = answerSet.reduce(reducer, []);

--- a/test/enumspec.test.ts
+++ b/test/enumspec.test.ts
@@ -47,7 +47,7 @@ describe('enumspec', () => {
     it('should return full enumSpec with other properties preserved', () => {
       const binQuery = initEnumSpec({values: [true, false], maxbins: 30}, 'b1', [true, false]);
       assert.deepEqual(binQuery.values, [true, false]);
-      assert.equal(binQuery.maxbins, 30);
+      assert.equal(binQuery['maxbins'], 30);
       assert.equal(binQuery.name, 'b1');
     });
   });

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -80,7 +80,7 @@ describe('SpecQueryModel', () => {
         // check if type is enumspec
         assert.isTrue(isEnumSpec(specM.getEncodingQueryByIndex(0).type));
         // check if enumeration specifier index has an index for type
-        assert.isOk(specM.enumSpecIndex.type);
+        assert.isOk(specM.enumSpecIndex.encodings[0].type);
       });
     });
 
@@ -98,7 +98,8 @@ describe('SpecQueryModel', () => {
         specQ.encodings[0][prop] = SHORT_ENUM_SPEC;
 
         const enumSpecIndex = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG).enumSpecIndex;
-        assert.isOk(enumSpecIndex[prop]);
+        assert.isOk(enumSpecIndex.encodingIndicesByProperty[prop]);
+        assert.isOk(enumSpecIndex.encodings[0][prop]);
       });
 
       it('should have ' + prop + ' enumSpecIndex if it is an EnumSpec.', () => {
@@ -112,7 +113,8 @@ describe('SpecQueryModel', () => {
         };
 
         const enumSpecIndex = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG).enumSpecIndex;
-        assert.isOk(enumSpecIndex[prop]);
+        assert.isOk(enumSpecIndex.encodingIndicesByProperty[prop]);
+        assert.isOk(enumSpecIndex.encodings[0][prop]);
       });
 
       it('should not have ' + prop + ' enumSpecIndex if it is specific.', () => {
@@ -120,7 +122,8 @@ describe('SpecQueryModel', () => {
         // do not set to enum spec = make it specific
 
         const enumSpecIndex = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG).enumSpecIndex;
-        assert.isNotOk(enumSpecIndex[prop]);
+        assert.isNotOk(enumSpecIndex.encodingIndicesByProperty[prop]);
+        assert.isNotOk(enumSpecIndex.encodings[0]);
       });
     });
 
@@ -136,7 +139,8 @@ describe('SpecQueryModel', () => {
         specQ.encodings[0][parent][child] = SHORT_ENUM_SPEC;
 
         const enumSpecIndex = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG).enumSpecIndex;
-        assert.isOk(enumSpecIndex[prop]);
+        assert.isOk(enumSpecIndex.encodingIndicesByProperty[prop]);
+        assert.isOk(enumSpecIndex.encodings[0][prop]);
       });
 
       it('should have ' + prop + ' enumSpecIndex if it is an EnumSpec.', () => {
@@ -147,14 +151,16 @@ describe('SpecQueryModel', () => {
         };
 
         const enumSpecIndex = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG).enumSpecIndex;
-        assert.isOk(enumSpecIndex[prop]);
+        assert.isOk(enumSpecIndex.encodingIndicesByProperty[prop]);
+        assert.isOk(enumSpecIndex.encodings[0][prop]);
       });
 
       it('should not have ' + prop + ' enumSpecIndex if it is specific.', () => {
         let specQ = duplicate(templateSpecQ);
 
         const enumSpecIndex = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG).enumSpecIndex;
-        assert.isNotOk(enumSpecIndex[prop]);
+        assert.isNotOk(enumSpecIndex.encodingIndicesByProperty[prop]);
+        assert.isNotOk(enumSpecIndex.encodings[0]);
       });
     });
 
@@ -171,8 +177,8 @@ describe('SpecQueryModel', () => {
       });
 
       it('should add new channel and autoCount to the enumSpec', () => {
-        assert.equal(model.enumSpecIndex.autoCount[0].index, 1);
-        assert.equal(model.enumSpecIndex.channel[0].index, 1);
+        assert.equal(model.enumSpecIndex.encodingIndicesByProperty['autoCount'][0], 1);
+        assert.equal(model.enumSpecIndex.encodingIndicesByProperty['channel'][0], 1);
       });
     });
   });


### PR DESCRIPTION
- add `encodingIndicesByProperty` and `encodings`
- remove each properties from the top-level of `enumSpecIndex` as it's getting too messy.

part of #159