### PR TITLE
Add basic support for encoding sort

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,12 @@ export interface QueryConfig {
   // TODO: Come back and implement correctly when designing sort enumeration.
   sorts?: SortOrder[];
 
+  sortFields?: string[];
+
+  sortOps?: AggregateOp[];
+
+  sortOrders?: SortOrder[];
+
   scaleBandSizes?: number[];
 
   scaleDomains?: Array<number[] | string[]>;
@@ -110,6 +116,9 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
 
   // TODO: Come back and implement correctly when designing sort enumeration.
   sorts: [SortOrder.ASCENDING, SortOrder.DESCENDING],
+  sortFields: [undefined],
+  sortOps: [undefined, AggregateOp.MEAN],
+  sortOrders: [SortOrder.ASCENDING, SortOrder.DESCENDING],
 
   scaleBandSizes: [17, 21],
   scaleDomains: [undefined],

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import {ScaleType} from 'vega-lite/src/scale';
 import {TimeUnit} from 'vega-lite/src/timeunit';
 import {Type} from 'vega-lite/src/type';
 
+import {SortOrder} from './query/encoding';
 import {Property, DEFAULT_PROPERTY_PRECEDENCE} from './property';
 
 export interface QueryConfig {
@@ -35,6 +36,9 @@ export interface QueryConfig {
 
   /** Default maxbins to enumerate */
   maxBinsList?: number[];
+
+  // TODO: Come back and implement correctly when designing sort enumeration.
+  sorts?: SortOrder[];
 
   scaleBandSizes?: number[];
 
@@ -103,6 +107,9 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
   types: [Type.NOMINAL, Type.ORDINAL, Type.QUANTITATIVE, Type.TEMPORAL],
 
   maxBinsList: [5, 10, 20],
+
+  // TODO: Come back and implement correctly when designing sort enumeration.
+  sorts: [SortOrder.ASCENDING, SortOrder.DESCENDING],
 
   scaleBandSizes: [17, 21],
   scaleDomains: [undefined],

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,7 +116,6 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
 
   // TODO: Come back and implement correctly when designing sort enumeration.
   sorts: [SortOrder.ASCENDING, SortOrder.DESCENDING],
-  sortFields: [undefined],
   sortOps: [undefined, AggregateOp.MEAN],
   sortOrders: [SortOrder.ASCENDING, SortOrder.DESCENDING],
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,10 +3,10 @@ import {AggregateOp} from 'vega-lite/src/aggregate';
 import {Config} from 'vega-lite/src/config';
 import {Mark} from 'vega-lite/src/mark';
 import {ScaleType} from 'vega-lite/src/scale';
+import {SortOrder} from 'vega-lite/src/sort';
 import {TimeUnit} from 'vega-lite/src/timeunit';
 import {Type} from 'vega-lite/src/type';
 
-import {SortOrder} from './query/encoding';
 import {Property, DEFAULT_PROPERTY_PRECEDENCE} from './property';
 
 export interface QueryConfig {
@@ -116,7 +116,7 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
 
   // TODO: Come back and implement correctly when designing sort enumeration.
   sorts: [SortOrder.ASCENDING, SortOrder.DESCENDING],
-  sortOps: [undefined, AggregateOp.MEAN],
+  sortOps: [AggregateOp.MIN, AggregateOp.MEAN],
   sortOrders: [SortOrder.ASCENDING, SortOrder.DESCENDING],
 
   scaleBandSizes: [17, 21],

--- a/src/model.ts
+++ b/src/model.ts
@@ -32,6 +32,8 @@ export function getDefaultName(prop: Property) {
       return 'b';
     case Property.BIN_MAXBINS:
       return 'b-mb';
+    case Property.SORT:
+      return 'so';
     case Property.SCALE:
       return 's';
     case Property.SCALE_BANDSIZE:
@@ -95,6 +97,9 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
 
     case Property.MARK:
       return opt.marks;
+
+    case Property.SORT:
+      return opt.sorts;
 
     case Property.SCALE_BANDSIZE:
       return opt.scaleBandSizes;
@@ -391,7 +396,7 @@ export class SpecQueryModel {
       if (isEnumSpec(encQ.channel)) return null;
 
       // assemble other property into a field def.
-      const PROPERTIES = [Property.AGGREGATE, Property.BIN, Property.SCALE, Property.TIMEUNIT, Property.FIELD, Property.TYPE];
+      const PROPERTIES = [Property.AGGREGATE, Property.BIN, Property.SORT, Property.SCALE, Property.TIMEUNIT, Property.FIELD, Property.TYPE];
       for (let j = 0; j < PROPERTIES.length; j++) {
         const prop = PROPERTIES[j];
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -76,6 +76,7 @@ export function getDefaultName(prop: Property) {
 export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryConfig): any[] {
   switch (prop) {
     case Property.FIELD:       // For field, by default enumerate all fields
+    case Property.SORT_FIELD:
       return schema.fields();
 
     // True, False for boolean values
@@ -106,9 +107,6 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
 
     case Property.SORT:
       return opt.sorts;
-
-    case Property.SORT_FIELD:
-      return opt.sortFields;
 
     case Property.SORT_OP:
       return opt.sortOps;

--- a/src/model.ts
+++ b/src/model.ts
@@ -34,6 +34,12 @@ export function getDefaultName(prop: Property) {
       return 'b-mb';
     case Property.SORT:
       return 'so';
+    case Property.SORT_FIELD:
+      return 'so-f';
+    case Property.SORT_OP:
+      return 'so-op';
+    case Property.SORT_ORDER:
+      return 'so-or';
     case Property.SCALE:
       return 's';
     case Property.SCALE_BANDSIZE:
@@ -100,6 +106,15 @@ export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryC
 
     case Property.SORT:
       return opt.sorts;
+
+    case Property.SORT_FIELD:
+      return opt.sortFields;
+
+    case Property.SORT_OP:
+      return opt.sortOps;
+
+    case Property.SORT_ORDER:
+      return opt.sortOrders;
 
     case Property.SCALE_BANDSIZE:
       return opt.scaleBandSizes;

--- a/src/property.ts
+++ b/src/property.ts
@@ -17,7 +17,8 @@ export enum Property {
   FIELD = 'field' as any,
   TYPE = 'type' as any,
 
-  // TODO: Sort
+  // - Sort
+  SORT = 'sort' as any,
 
   // - Scale
   SCALE = 'scale' as any,
@@ -46,6 +47,7 @@ export function hasNestedProperty(prop: Property) {
   switch (prop) {
     case Property.BIN:
     case Property.SCALE:
+    case Property.SORT:
       // TODO: AXIS, LEGEND
       return true;
     case Property.MARK:
@@ -81,6 +83,7 @@ export const ENCODING_PROPERTIES = [
   Property.AUTOCOUNT,
   Property.FIELD,
   Property.TYPE,
+  Property.SORT,
   Property.SCALE,
   Property.SCALE_BANDSIZE,
   Property.SCALE_CLAMP,
@@ -104,6 +107,7 @@ export const DEFAULT_PROPERTY_PRECEDENCE: Property[] =  [
   Property.TIMEUNIT,
   Property.AGGREGATE,
   Property.AUTOCOUNT,
+  Property.SORT,
 
   // Nested Transform Property
   Property.BIN_MAXBINS,

--- a/src/property.ts
+++ b/src/property.ts
@@ -19,6 +19,9 @@ export enum Property {
 
   // - Sort
   SORT = 'sort' as any,
+  SORT_FIELD = 'sortField' as any,
+  SORT_OP = 'sortOp' as any,
+  SORT_ORDER = 'sortOrder' as any,
 
   // - Scale
   SCALE = 'scale' as any,
@@ -84,6 +87,9 @@ export const ENCODING_PROPERTIES = [
   Property.FIELD,
   Property.TYPE,
   Property.SORT,
+  Property.SORT_FIELD,
+  Property.SORT_OP,
+  Property.SORT_ORDER,
   Property.SCALE,
   Property.SCALE_BANDSIZE,
   Property.SCALE_CLAMP,
@@ -107,7 +113,11 @@ export const DEFAULT_PROPERTY_PRECEDENCE: Property[] =  [
   Property.TIMEUNIT,
   Property.AGGREGATE,
   Property.AUTOCOUNT,
+
   Property.SORT,
+  Property.SORT_FIELD,
+  Property.SORT_OP,
+  Property.SORT_ORDER,
 
   // Nested Transform Property
   Property.BIN_MAXBINS,
@@ -141,6 +151,21 @@ export const NESTED_ENCODING_PROPERTIES: NestedEncodingProperty[] = [
     property: Property.BIN_MAXBINS,
     parent: 'bin',
     child: 'maxbins'
+  },
+  {
+    property: Property.SORT_FIELD,
+    parent: 'sort',
+    child: 'field'
+  },
+  {
+    property: Property.SORT_OP,
+    parent: 'sort',
+    child: 'op'
+  },
+  {
+    property: Property.SORT_ORDER,
+    parent: 'sort',
+    child: 'order'
   },
   {
     property: Property.SCALE_BANDSIZE,

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -21,7 +21,7 @@ export interface EncodingQuery {
   bin?: boolean | BinQuery | ShortEnumSpec;
   scale?: boolean | ScaleQuery | ShortEnumSpec;
 
-  sort?: SortOrder | SortFieldQuery | ShortEnumSpec;
+  sort?: SortOrder | SortField;
 
   field?: Field | EnumSpec<Field> | ShortEnumSpec;
   type?: Type | EnumSpec<Type> | ShortEnumSpec;
@@ -36,7 +36,7 @@ export enum SortOrder {
     NONE = 'none' as any,
 }
 
-export interface SortFieldQuery {
+export interface SortField {
   /**
    * The field name to aggregate over.
    */

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -3,6 +3,7 @@ import {AggregateOp} from 'vega-lite/src/aggregate';
 import {defaultScaleType, TimeUnit} from 'vega-lite/src/timeunit';
 import {Type} from 'vega-lite/src/type';
 import {ScaleType} from 'vega-lite/src/scale';
+import {SortOrder, SortField} from 'vega-lite/src/sort';
 
 import {EnumSpec, isEnumSpec, ShortEnumSpec} from '../enumspec';
 import {contains} from '../util';
@@ -28,25 +29,6 @@ export interface EncodingQuery {
   // TODO: value
 
   // TODO: axisQuery, legendQuery
-}
-
-export enum SortOrder {
-    ASCENDING = 'ascending' as any,
-    DESCENDING = 'descending' as any,
-    NONE = 'none' as any,
-}
-
-export interface SortField {
-  /**
-   * The field name to aggregate over.
-   */
-  field: string;
-  /**
-   * The sort aggregation operator
-   */
-  op: AggregateOp;
-
-  order?: SortOrder;
 }
 
 export interface BinQuery extends EnumSpec<boolean> {

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -1,9 +1,9 @@
-import {Channel} from 'vega-lite/src/channel';
 import {AggregateOp} from 'vega-lite/src/aggregate';
-import {defaultScaleType, TimeUnit} from 'vega-lite/src/timeunit';
-import {Type} from 'vega-lite/src/type';
+import {Channel} from 'vega-lite/src/channel';
 import {ScaleType} from 'vega-lite/src/scale';
 import {SortOrder, SortField} from 'vega-lite/src/sort';
+import {defaultScaleType, TimeUnit} from 'vega-lite/src/timeunit';
+import {Type} from 'vega-lite/src/type';
 
 import {EnumSpec, isEnumSpec, ShortEnumSpec} from '../enumspec';
 import {contains} from '../util';

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -21,11 +21,32 @@ export interface EncodingQuery {
   bin?: boolean | BinQuery | ShortEnumSpec;
   scale?: boolean | ScaleQuery | ShortEnumSpec;
 
+  sort?: SortOrder | SortFieldQuery | ShortEnumSpec;
+
   field?: Field | EnumSpec<Field> | ShortEnumSpec;
   type?: Type | EnumSpec<Type> | ShortEnumSpec;
   // TODO: value
 
   // TODO: axisQuery, legendQuery
+}
+
+export enum SortOrder {
+    ASCENDING = 'ascending' as any,
+    DESCENDING = 'descending' as any,
+    NONE = 'none' as any,
+}
+
+export interface SortFieldQuery {
+  /**
+   * The field name to aggregate over.
+   */
+  field: string;
+  /**
+   * The sort aggregation operator
+   */
+  op: AggregateOp;
+
+  order?: SortOrder;
 }
 
 export interface BinQuery extends EnumSpec<boolean> {

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -1,6 +1,6 @@
 import {Type} from 'vega-lite/src/type';
 
-import {EncodingQuery} from './encoding';
+import {EncodingQuery, SortFieldQuery} from './encoding';
 import {SpecQuery, stack} from './spec';
 import {isEnumSpec, SHORT_ENUM_SPEC} from '../enumspec';
 
@@ -119,6 +119,15 @@ export function fieldDef(encQ: EncodingQuery,
       props.push({
         key: 'maxbins',
         value: value(encQ.bin['maxbins'], replace[Property.BIN_MAXBINS])
+      });
+    }
+  } else if (include[Property.SORT] && encQ.sort && !isEnumSpec(encQ.sort)) {
+    if ((encQ.sort as SortFieldQuery)['op']) {
+      // TODO
+    } else {
+     props.push({
+       key: 'sort',
+       value: encQ.sort
       });
     }
   } else {

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -122,9 +122,7 @@ export function fieldDef(encQ: EncodingQuery,
       });
     }
   } else if (include[Property.SORT] && encQ.sort && !isEnumSpec(encQ.sort)) {
-    if ((encQ.sort as SortFieldQuery)['op']) {
-      // TODO
-    } else {
+    if (!(encQ.sort as SortFieldQuery)['op']) {
      props.push({
        key: 'sort',
        value: encQ.sort
@@ -141,7 +139,7 @@ export function fieldDef(encQ: EncodingQuery,
 
   // Scale
   // TODO: axis, legend
-  for (const nestedPropParent of [Property.SCALE]) {
+  for (const nestedPropParent of [Property.SCALE, Property.SORT]) {
     if (include[nestedPropParent]) {
       if (encQ[nestedPropParent] && !isEnumSpec(encQ[nestedPropParent])) {
         const nestedProps = getNestedEncodingPropertyChildren(nestedPropParent);

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -1,6 +1,6 @@
 import {Type} from 'vega-lite/src/type';
 
-import {EncodingQuery, SortFieldQuery} from './encoding';
+import {EncodingQuery} from './encoding';
 import {SpecQuery, stack} from './spec';
 import {isEnumSpec, SHORT_ENUM_SPEC} from '../enumspec';
 
@@ -121,13 +121,6 @@ export function fieldDef(encQ: EncodingQuery,
         value: value(encQ.bin['maxbins'], replace[Property.BIN_MAXBINS])
       });
     }
-  } else if (include[Property.SORT] && encQ.sort && !isEnumSpec(encQ.sort)) {
-    if (!(encQ.sort as SortFieldQuery)['op']) {
-     props.push({
-       key: 'sort',
-       value: encQ.sort
-      });
-    }
   } else {
     for (const prop of [Property.AGGREGATE, Property.AUTOCOUNT, Property.TIMEUNIT, Property.BIN]) {
       if (include[prop] && encQ[prop] && isEnumSpec(encQ[prop])) {
@@ -141,7 +134,12 @@ export function fieldDef(encQ: EncodingQuery,
   // TODO: axis, legend
   for (const nestedPropParent of [Property.SCALE, Property.SORT]) {
     if (include[nestedPropParent]) {
-      if (encQ[nestedPropParent] && !isEnumSpec(encQ[nestedPropParent])) {
+      if (typeof encQ[nestedPropParent] === 'string') {
+        props.push({
+          key: nestedPropParent + '',
+          value: encQ[nestedPropParent]
+        });
+      } else if (encQ[nestedPropParent] && !isEnumSpec(encQ[nestedPropParent])) {
         const nestedProps = getNestedEncodingPropertyChildren(nestedPropParent);
         const nestedPropChildren = nestedProps.reduce((p, nestedProp) => {
           if (include[nestedProp.property] && encQ[nestedPropParent][nestedProp.child] !== undefined) {

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -136,29 +136,30 @@ export function fieldDef(encQ: EncodingQuery,
   for (const nestedPropParent of [Property.SCALE, Property.SORT]) {
     if (include[nestedPropParent]) {
       if (encQ[nestedPropParent] && !isEnumSpec(encQ[nestedPropParent])) {
-        // Sort can be a string
+        // `sort` can be a string (ascending/descending).
         if (isString(encQ[nestedPropParent])) {
           props.push({
             key: nestedPropParent + '',
             value: encQ[nestedPropParent]
           });
-        }
-
-        const nestedProps = getNestedEncodingPropertyChildren(nestedPropParent);
-        const nestedPropChildren = nestedProps.reduce((p, nestedProp) => {
-          if (include[nestedProp.property] && encQ[nestedPropParent][nestedProp.child] !== undefined) {
-            p[nestedProp.child] = value(encQ[nestedPropParent][nestedProp.child], replace[nestedProp.property]);
+        } else {
+          const nestedProps = getNestedEncodingPropertyChildren(nestedPropParent);
+          const nestedPropChildren = nestedProps.reduce((p, nestedProp) => {
+            if (include[nestedProp.property] && encQ[nestedPropParent][nestedProp.child] !== undefined) {
+              p[nestedProp.child] = value(encQ[nestedPropParent][nestedProp.child], replace[nestedProp.property]);
+            }
+            return p;
+          }, {});
+  
+          if(keys(nestedPropChildren).length > 0) {
+            props.push({
+              key: nestedPropParent + '',
+              value: JSON.stringify(nestedPropChildren)
+            });
           }
-          return p;
-        }, {});
-
-        if(keys(nestedPropChildren).length > 0) {
-          props.push({
-            key: nestedPropParent + '',
-            value: JSON.stringify(nestedPropChildren)
-          });
         }
       } else if (encQ[nestedPropParent] === false || encQ[nestedPropParent] === null) {
+        // `scale`, `axis`, `legend` can be false/null. 
         props.push({
           key: nestedPropParent + '',
           value: false

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -1,4 +1,5 @@
 import {Type} from 'vega-lite/src/type';
+import {isString} from 'datalib/src/util';
 
 import {EncodingQuery} from './encoding';
 import {SpecQuery, stack} from './spec';
@@ -134,12 +135,14 @@ export function fieldDef(encQ: EncodingQuery,
   // TODO: axis, legend
   for (const nestedPropParent of [Property.SCALE, Property.SORT]) {
     if (include[nestedPropParent]) {
-      if (typeof encQ[nestedPropParent] === 'string') {
-        props.push({
-          key: nestedPropParent + '',
-          value: encQ[nestedPropParent]
-        });
-      } else if (encQ[nestedPropParent] && !isEnumSpec(encQ[nestedPropParent])) {
+      if (encQ[nestedPropParent] && !isEnumSpec(encQ[nestedPropParent])) {
+        if (isString(encQ[nestedPropParent])) {
+          props.push({
+            key: nestedPropParent + '',
+            value: encQ[nestedPropParent]
+          });
+        }
+
         const nestedProps = getNestedEncodingPropertyChildren(nestedPropParent);
         const nestedPropChildren = nestedProps.reduce((p, nestedProp) => {
           if (include[nestedProp.property] && encQ[nestedPropParent][nestedProp.child] !== undefined) {

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -150,7 +150,7 @@ export function fieldDef(encQ: EncodingQuery,
             }
             return p;
           }, {});
-  
+
           if(keys(nestedPropChildren).length > 0) {
             props.push({
               key: nestedPropParent + '',

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -136,6 +136,7 @@ export function fieldDef(encQ: EncodingQuery,
   for (const nestedPropParent of [Property.SCALE, Property.SORT]) {
     if (include[nestedPropParent]) {
       if (encQ[nestedPropParent] && !isEnumSpec(encQ[nestedPropParent])) {
+        // Sort can be a string
         if (isString(encQ[nestedPropParent])) {
           props.push({
             key: nestedPropParent + '',

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -302,7 +302,7 @@ describe('SpecQueryModel', () => {
         transform: {filter: 'datum.A===1'},
         mark: Mark.BAR,
         encodings: [
-          {channel: Channel.X, field: 'A', sort: {field: 'A', op: AggregateOp.MEAN}, type: Type.QUANTITATIVE}
+          {channel: Channel.X, field: 'A', sort: {field: 'A', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE}
         ]
       });
 
@@ -312,7 +312,7 @@ describe('SpecQueryModel', () => {
         transform: {filter: 'datum.A===1'},
         mark: Mark.BAR,
         encoding: {
-          x: {field: 'A', sort: {field: 'A', op: AggregateOp.MEAN}, type: Type.QUANTITATIVE}
+          x: {field: 'A', sort: {field: 'A', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE}
         },
         config: DEFAULT_SPEC_CONFIG
       });

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -3,13 +3,13 @@ import {assert} from 'chai';
 import {AggregateOp} from 'vega-lite/src/aggregate';
 import {Channel} from 'vega-lite/src/channel';
 import {Mark} from 'vega-lite/src/mark';
+import {SortOrder} from 'vega-lite/src/sort';
 import {Type} from 'vega-lite/src/type';
 
 import {DEFAULT_QUERY_CONFIG} from '../src/config';
 import {SpecQueryModel, getDefaultName, getDefaultEnumValues} from '../src/model';
 import {Property, DEFAULT_PROPERTY_PRECEDENCE, ENCODING_PROPERTIES, NESTED_ENCODING_PROPERTIES} from '../src/property';
 import {SHORT_ENUM_SPEC, isEnumSpec} from '../src/enumspec';
-import {SortOrder} from '../src/query/encoding';
 import {SpecQuery} from '../src/query/spec';
 import {Schema} from '../src/schema';
 import {duplicate, extend} from '../src/util';
@@ -280,7 +280,9 @@ describe('SpecQueryModel', () => {
         transform: {filter: 'datum.A===1'},
         mark: Mark.BAR,
         encodings: [
-          {channel: Channel.X, field: 'A', sort: SortOrder.ASCENDING, type: Type.QUANTITATIVE}
+          {channel: Channel.X, field: 'A', sort: SortOrder.ASCENDING, type: Type.QUANTITATIVE},
+          {channel: Channel.Y, field: 'A', sort: {field: 'A', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE}
+
         ]
       });
 
@@ -290,29 +292,8 @@ describe('SpecQueryModel', () => {
         transform: {filter: 'datum.A===1'},
         mark: Mark.BAR,
         encoding: {
-          x: {field: 'A', sort: SortOrder.ASCENDING, type: Type.QUANTITATIVE}
-        },
-        config: DEFAULT_SPEC_CONFIG
-      });
-    });
-
-    it('should return a correct Vega-Lite spec if sort is a Sort field definition object', () => {
-      const specM = buildSpecQueryModel({
-        data: {values: [{A: 1}]},
-        transform: {filter: 'datum.A===1'},
-        mark: Mark.BAR,
-        encodings: [
-          {channel: Channel.X, field: 'A', sort: {field: 'A', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE}
-        ]
-      });
-
-      const spec = specM.toSpec();
-      assert.deepEqual(spec, {
-        data: {values: [{A: 1}]},
-        transform: {filter: 'datum.A===1'},
-        mark: Mark.BAR,
-        encoding: {
-          x: {field: 'A', sort: {field: 'A', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE}
+          x: {field: 'A', sort: SortOrder.ASCENDING, type: Type.QUANTITATIVE},
+          y: {field: 'A', sort: {field: 'A', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE}
         },
         config: DEFAULT_SPEC_CONFIG
       });

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -9,6 +9,7 @@ import {DEFAULT_QUERY_CONFIG} from '../src/config';
 import {SpecQueryModel, getDefaultName, getDefaultEnumValues} from '../src/model';
 import {Property, DEFAULT_PROPERTY_PRECEDENCE, ENCODING_PROPERTIES, NESTED_ENCODING_PROPERTIES} from '../src/property';
 import {SHORT_ENUM_SPEC, isEnumSpec} from '../src/enumspec';
+import {SortOrder} from '../src/query/encoding';
 import {SpecQuery} from '../src/query/spec';
 import {Schema} from '../src/schema';
 import {duplicate, extend} from '../src/util';
@@ -268,6 +269,50 @@ describe('SpecQueryModel', () => {
         mark: Mark.BAR,
         encoding: {
           x: {field: 'A', type: Type.QUANTITATIVE}
+        },
+        config: DEFAULT_SPEC_CONFIG
+      });
+    });
+
+    it('should return a correct Vega-Lite spec if the query has sort: SortOrder', () => {
+      const specM = buildSpecQueryModel({
+        data: {values: [{A: 1}]},
+        transform: {filter: 'datum.A===1'},
+        mark: Mark.BAR,
+        encodings: [
+          {channel: Channel.X, field: 'A', sort: SortOrder.ASCENDING, type: Type.QUANTITATIVE}
+        ]
+      });
+
+      const spec = specM.toSpec();
+      assert.deepEqual(spec, {
+        data: {values: [{A: 1}]},
+        transform: {filter: 'datum.A===1'},
+        mark: Mark.BAR,
+        encoding: {
+          x: {field: 'A', sort: SortOrder.ASCENDING, type: Type.QUANTITATIVE}
+        },
+        config: DEFAULT_SPEC_CONFIG
+      });
+    });
+
+    it('should return a correct Vega-Lite spec if sort is a Sort field definition object', () => {
+      const specM = buildSpecQueryModel({
+        data: {values: [{A: 1}]},
+        transform: {filter: 'datum.A===1'},
+        mark: Mark.BAR,
+        encodings: [
+          {channel: Channel.X, field: 'A', sort: {field: 'A', op: AggregateOp.MEAN}, type: Type.QUANTITATIVE}
+        ]
+      });
+
+      const spec = specM.toSpec();
+      assert.deepEqual(spec, {
+        data: {values: [{A: 1}]},
+        transform: {filter: 'datum.A===1'},
+        mark: Mark.BAR,
+        encoding: {
+          x: {field: 'A', sort: {field: 'A', op: AggregateOp.MEAN}, type: Type.QUANTITATIVE}
         },
         config: DEFAULT_SPEC_CONFIG
       });

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -5,6 +5,7 @@ import {ScaleType} from 'vega-lite/src/scale';
 import {TimeUnit} from 'vega-lite/src/timeunit';
 import {Type} from 'vega-lite/src/type';
 
+import {SortOrder} from '../../src/query/encoding';
 import {SHORT_ENUM_SPEC} from '../../src/enumspec';
 import {spec as specShorthand, encoding as encodingShorthand, fieldDef as fieldDefShorthand, INCLUDE_ALL, getReplacer} from '../../src/query/shorthand';
 import {REPLACE_BLANK_FIELDS} from '../../src/query/groupby';
@@ -157,6 +158,13 @@ describe('query/shorthand', () => {
         channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, timeUnit: SHORT_ENUM_SPEC
         });
       assert.equal(str, '?(a,q)');
+    });
+
+    it('should return correct fieldDefShorthand string for sort with ascending', () => {
+      const str = fieldDefShorthand({
+        channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, sort: SortOrder.ASCENDING
+      });
+      assert.equal(str, 'a,q,sort=ascending');
     });
 
     it('should return correct fieldDefShorthand string for scale with a string[] domain', () => {

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -2,9 +2,9 @@ import {AggregateOp} from 'vega-lite/src/aggregate';
 import {Channel} from 'vega-lite/src/channel';
 import {Mark} from 'vega-lite/src/mark';
 import {ScaleType} from 'vega-lite/src/scale';
+import {SortOrder} from 'vega-lite/src/sort';
 import {TimeUnit} from 'vega-lite/src/timeunit';
 import {Type} from 'vega-lite/src/type';
-import {SortOrder} from 'vega-lite/src/sort';
 
 import {SHORT_ENUM_SPEC} from '../../src/enumspec';
 import {spec as specShorthand, encoding as encodingShorthand, fieldDef as fieldDefShorthand, INCLUDE_ALL, getReplacer} from '../../src/query/shorthand';

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -4,8 +4,8 @@ import {Mark} from 'vega-lite/src/mark';
 import {ScaleType} from 'vega-lite/src/scale';
 import {TimeUnit} from 'vega-lite/src/timeunit';
 import {Type} from 'vega-lite/src/type';
+import {SortOrder} from 'vega-lite/src/sort';
 
-import {SortOrder} from '../../src/query/encoding';
 import {SHORT_ENUM_SPEC} from '../../src/enumspec';
 import {spec as specShorthand, encoding as encodingShorthand, fieldDef as fieldDefShorthand, INCLUDE_ALL, getReplacer} from '../../src/query/shorthand';
 import {REPLACE_BLANK_FIELDS} from '../../src/query/groupby';

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -167,6 +167,35 @@ describe('query/shorthand', () => {
       assert.equal(str, 'a,q,sort=ascending');
     });
 
+    it('should return correct fieldDefShorthand string for sort field definition object', () => {
+      const str = fieldDefShorthand({
+        channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, sort: {field: 'a', op: AggregateOp.MEAN, order: SortOrder.DESCENDING}
+      });
+      assert.equal(str, 'a,q,sort={"field":"a","op":"mean","order":"descending"}');
+    });
+
+    it('should return correct fieldDefShorthand string for bin with sort field definition object', () => {
+      const str = fieldDefShorthand({
+        bin: true, channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, sort: {field: 'a', op: AggregateOp.MEAN, order: SortOrder.DESCENDING}
+      });
+      assert.equal(str, 'bin(a,q,sort={"field":"a","op":"mean","order":"descending"})');
+    });
+
+    it('should return correct fieldDefShorthand string for bin with maxbins and sort field definition object', () => {
+      const str = fieldDefShorthand({
+        bin: {maxbins: 20}, channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, sort: {field: 'a', op: AggregateOp.MEAN, order: SortOrder.DESCENDING}
+      });
+      assert.equal(str, 'bin(a,q,maxbins=20,sort={"field":"a","op":"mean","order":"descending"})');
+    });
+
+    it('should return correct fieldDefShorthand string for bin with maxbins, scale with scaleType ' +
+       'and sort field definition object', () => {
+      const str = fieldDefShorthand({
+        bin: {maxbins: 20}, channel: Channel.X, field: 'a', type: Type.QUANTITATIVE, scale: {type: ScaleType.LOG}, sort: {field: 'a', op: AggregateOp.MEAN, order: SortOrder.DESCENDING}
+      });
+      assert.equal(str, 'bin(a,q,maxbins=20,scale={"type":"log"},sort={"field":"a","op":"mean","order":"descending"})');
+    });
+
     it('should return correct fieldDefShorthand string for scale with a string[] domain', () => {
       const str = fieldDefShorthand({
         channel: Channel.X, field: 'a', type: Type.NOMINAL, scale: {domain: ['cats', 'dogs']}

--- a/test/query/spec.test.ts
+++ b/test/query/spec.test.ts
@@ -2,11 +2,11 @@ import {AggregateOp} from 'vega-lite/src/aggregate';
 import {Channel} from 'vega-lite/src/channel';
 import {Mark, BAR, AREA, PRIMITIVE_MARKS} from 'vega-lite/src/mark';
 import {StackOffset} from 'vega-lite/src/stack';
+import {SortOrder} from 'vega-lite/src/sort';
 import {Type} from 'vega-lite/src/type';
 
 import {assert} from 'chai';
 
-import {SortOrder} from '../../src/query/encoding';
 import {fromSpec, stack} from '../../src/query/spec';
 import {without} from '../../src/util';
 
@@ -233,14 +233,14 @@ describe('query/spec', () => {
       });
     });
 
-    it('should produce correct SpecQuery with sort: SortOrder', () => {
+    it('should produce correct SpecQuery with Sort', () => {
       const specQ = fromSpec({
         data: {values: [{x: 1}, {x: 2}]},
         transform: {filter: 'datum.x ===2'},
         mark: Mark.POINT,
         encoding: {
           x: {field: 'x', sort: SortOrder.ASCENDING, type: Type.QUANTITATIVE},
-          y: {field: 'x', type: Type.QUANTITATIVE, scale: null}
+          y: {field: 'x', sort: {field: 'x', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE, scale: null}
         },
         config: {}
       });
@@ -250,35 +250,11 @@ describe('query/spec', () => {
         mark: Mark.POINT,
         encodings: [
           {channel: 'x', field: 'x', sort: SortOrder.ASCENDING, type: Type.QUANTITATIVE},
-          {channel: 'y', field: 'x', type: Type.QUANTITATIVE, scale: false}
+          {channel: 'y', field: 'x',  sort: {field: 'x', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE, scale: false}
         ],
         config: {}
       });
     });
-
-    it('should produce correct SpecQuery with sort: SortField definition object', () => {
-      const specQ = fromSpec({
-        data: {values: [{x: 1}, {x: 2}]},
-        transform: {filter: 'datum.x ===2'},
-        mark: Mark.POINT,
-        encoding: {
-          x: {field: 'x', sort: {field: 'x', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE},
-          y: {field: 'x', type: Type.QUANTITATIVE, scale: null}
-        },
-        config: {}
-      });
-      assert.deepEqual(specQ, {
-        data: {values: [{x: 1}, {x: 2}]},
-        transform: {filter: 'datum.x ===2'},
-        mark: Mark.POINT,
-        encodings: [
-          {channel: 'x', field: 'x', sort: {field: 'x', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE},
-          {channel: 'y', field: 'x', type: Type.QUANTITATIVE, scale: false}
-        ],
-        config: {}
-      });
-    });
-
 
     it('should produce correct SpecQuery without data, transform, config', () => {
       const specQ = fromSpec({

--- a/test/query/spec.test.ts
+++ b/test/query/spec.test.ts
@@ -6,6 +6,7 @@ import {Type} from 'vega-lite/src/type';
 
 import {assert} from 'chai';
 
+import {SortOrder} from '../../src/query/encoding';
 import {fromSpec, stack} from '../../src/query/spec';
 import {without} from '../../src/util';
 
@@ -231,6 +232,53 @@ describe('query/spec', () => {
         config: {}
       });
     });
+
+    it('should produce correct SpecQuery with sort: SortOrder', () => {
+      const specQ = fromSpec({
+        data: {values: [{x: 1}, {x: 2}]},
+        transform: {filter: 'datum.x ===2'},
+        mark: Mark.POINT,
+        encoding: {
+          x: {field: 'x', sort: SortOrder.ASCENDING, type: Type.QUANTITATIVE},
+          y: {field: 'x', type: Type.QUANTITATIVE, scale: null}
+        },
+        config: {}
+      });
+      assert.deepEqual(specQ, {
+        data: {values: [{x: 1}, {x: 2}]},
+        transform: {filter: 'datum.x ===2'},
+        mark: Mark.POINT,
+        encodings: [
+          {channel: 'x', field: 'x', sort: SortOrder.ASCENDING, type: Type.QUANTITATIVE},
+          {channel: 'y', field: 'x', type: Type.QUANTITATIVE, scale: false}
+        ],
+        config: {}
+      });
+    });
+
+    it('should produce correct SpecQuery with sort: SortField definition object', () => {
+      const specQ = fromSpec({
+        data: {values: [{x: 1}, {x: 2}]},
+        transform: {filter: 'datum.x ===2'},
+        mark: Mark.POINT,
+        encoding: {
+          x: {field: 'x', sort: {field: 'x', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE},
+          y: {field: 'x', type: Type.QUANTITATIVE, scale: null}
+        },
+        config: {}
+      });
+      assert.deepEqual(specQ, {
+        data: {values: [{x: 1}, {x: 2}]},
+        transform: {filter: 'datum.x ===2'},
+        mark: Mark.POINT,
+        encodings: [
+          {channel: 'x', field: 'x', sort: {field: 'x', op: AggregateOp.MEAN, order: SortOrder.ASCENDING}, type: Type.QUANTITATIVE},
+          {channel: 'y', field: 'x', type: Type.QUANTITATIVE, scale: false}
+        ],
+        config: {}
+      });
+    });
+
 
     it('should produce correct SpecQuery without data, transform, config', () => {
       const specQ = fromSpec({


### PR DESCRIPTION
fix #150 
  - Add sort property and sort child properties
  - Support encoding.sort in SpecModel.toSpec()
  - Support shorthand with sort


