### PR TITLE
[WIP] Modify stack shorthand to include stacked field.

### DIFF
--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -66,7 +66,7 @@ export function isAggregate(specQ: SpecQuery) {
 /**
  * @return the stack offset type for the specQuery
  */
-export function stack(specQ: SpecQuery): StackProperties {
+export function stack(specQ: SpecQuery): StackProperties & {fieldEncQ: EncodingQuery, groupByEncQ: EncodingQuery} {
   const config = specQ.config;
   const stacked = (config && config.mark) ? config.mark.stacked : undefined;
 
@@ -109,7 +109,9 @@ export function stack(specQ: SpecQuery): StackProperties {
   if (xIsAggregate !== yIsAggregate) {
     return {
       groupbyChannel: xIsAggregate ? (!!yEncQ ? Y : null) : (!!xEncQ ? X : null),
+      groupByEncQ: xIsAggregate ? yEncQ : xEncQ,
       fieldChannel: xIsAggregate ? X : Y,
+      fieldEncQ: xIsAggregate ? xEncQ : yEncQ,
       stackByChannels: stackByChannels,
       offset: stacked || StackOffset.ZERO
     };

--- a/test/nest.test.ts
+++ b/test/nest.test.ts
@@ -278,7 +278,7 @@ describe('nest', () => {
         return !contains([Mark.BAR, Mark.AREA], item.getMark());
       });
 
-      assert.equal((groups[1] as SpecQueryModelGroup).name, 'stack=zero|style:N1,n|xy:N,n|xy:sum(Q,q)');
+      assert.equal((groups[1] as SpecQueryModelGroup).name, 'stack={field:sum(Q),by:N,offset:zero}|style:N1,n|xy:N,n|xy:sum(Q,q)');
       (groups[1] as SpecQueryModelGroup).items.forEach((item: SpecQueryModel) => {
         return contains([Mark.BAR, Mark.AREA], item.getMark());
       });
@@ -328,7 +328,7 @@ describe('nest', () => {
         return !contains([Mark.BAR, Mark.AREA], (item.items[0] as SpecQueryModel).getMark());
       });
 
-      assert.equal((groups[1] as SpecQueryModelGroup).name, 'stack=zero|style:N1,n|xy:N,n|xy:sum(Q,q)');
+      assert.equal((groups[1] as SpecQueryModelGroup).name, 'stack={field:sum(Q),by:N,offset:zero}|style:N1,n|xy:N,n|xy:sum(Q,q)');
       (groups[1] as SpecQueryModelGroup).items.forEach((item: SpecQueryModelGroup) => {
         return contains([Mark.BAR, Mark.AREA], (item.items[0] as SpecQueryModel).getMark());
       });

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -79,7 +79,7 @@ describe('query/shorthand', () => {
           {channel: Channel.COLOR, field: 'n1', type: Type.NOMINAL}
         ]
       });
-      assert.equal(str, 'bar|stack=zero|color:n1,n|x:sum(q,q)|y:n,n');
+      assert.equal(str, 'bar|stack={field:sum(q),by:n,offset:zero}|color:n1,n|x:sum(q,q)|y:n,n');
     });
 
     it('should return correct spec string for ambiguous specQuery', () => {


### PR DESCRIPTION
For example,

```diff
-   assert.equal(str, 'bar|stack=zero|color:n1,n|x:sum(q,q)|y:n,n');
+  assert.equal(str, 'bar|stack={field:sum(Q),by:n,offset:zero}|color:n1,n|x:sum(q,q)|y:n,n');
```

Fix #191