### PR TITLE
[Follow-up]  Test for #199 and revert `omitAggregate` to allow enum spec

### DIFF
--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -233,7 +233,7 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
     name: 'omitAggregate',
     description: 'Omit aggregate plots.',
     properties: [Property.AGGREGATE, Property.AUTOCOUNT],
-    allowEnumSpecForProperties: false,
+    allowEnumSpecForProperties: true,
     strict: false,
     satisfy: (specM: SpecQueryModel, schema: Schema, opt: QueryConfig) => {
       if (specM.isAggregate()) {

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -858,7 +858,7 @@ describe('constraints/spec', () => {
       assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRaw'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
     });
 
-    it('should not exclude aggregate if aggregate if it is still an enum spec', () => {
+    it('should not exclude aggregate if it is still an enum spec', () => {
       const specM = buildSpecQueryModel({
         mark: Mark.POINT,
         encodings: [

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -858,7 +858,7 @@ describe('constraints/spec', () => {
       assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRaw'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
     });
 
-    it('should not exclude aggregate if it is still an enum spec', () => {
+    it('It should return true if there is an enum spec aggregate', () => {
       const specM = buildSpecQueryModel({
         mark: Mark.POINT,
         encodings: [
@@ -868,7 +868,7 @@ describe('constraints/spec', () => {
       assert.isTrue(SPEC_CONSTRAINT_INDEX['omitRaw'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
     });
 
-    it('should not exclude autocount if it is still an enum spec', () => {
+    it('It should return true if there is an enum spec autoCount', () => {
       const specM = buildSpecQueryModel({
         mark: Mark.POINT,
         encodings: [

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -858,6 +858,26 @@ describe('constraints/spec', () => {
       assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRaw'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
     });
 
+    it('should not exclude aggregate if aggregate if it is still an enum spec', () => {
+      const specM = buildSpecQueryModel({
+        mark: Mark.POINT,
+        encodings: [
+          {aggregate: SHORT_ENUM_SPEC, channel: Channel.X, field: 'A', type: Type.QUANTITATIVE}
+        ]
+      });
+      assert.isTrue(SPEC_CONSTRAINT_INDEX['omitRaw'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+    });
+
+    it('should not exclude autocount if it is still an enum spec', () => {
+      const specM = buildSpecQueryModel({
+        mark: Mark.POINT,
+        encodings: [
+          {autoCount: SHORT_ENUM_SPEC, channel: Channel.X, field: 'A', type: Type.QUANTITATIVE}
+        ]
+      });
+      assert.isTrue(SPEC_CONSTRAINT_INDEX['omitRaw'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+    });
+
     it('should return true if data is aggregate', () => {
       const specM = buildSpecQueryModel({
         mark: Mark.POINT,


### PR DESCRIPTION
fix #199 
- Add test: do not exclude autocount if it is still enumspec for omitRaw constraint
- Add test: do not exclude aggregate if it is still enumspec for omitRaw constraint
- set allowEnumSpecForProperties: true for omitAggregate constraint