### PR TITLE
Refactor: Rename EnumSpec's `values` to `enum`

### DIFF
--- a/src/enumerator.ts
+++ b/src/enumerator.ts
@@ -24,7 +24,7 @@ ENUMERATOR_INDEX[Property.MARK] = (enumSpecIndex: EnumSpecIndex, schema: Schema,
     const markEnumSpec = specM.getMark() as EnumSpec<Mark>;
 
     // enumerate the value
-    markEnumSpec.values.forEach((mark) => {
+    markEnumSpec.enum.forEach((mark) => {
       specM.setMark(mark);
       // Check spec constraint
       const violatedSpecConstraint = checkSpec(Property.MARK, enumSpecIndex.mark, specM, schema, opt);
@@ -86,7 +86,7 @@ export function EncodingPropertyGeneratorFactory(prop: Property): EnumeratorFact
           ) { // TODO: encQ.excluded
           enumerate(jobIndex + 1);
         } else {
-          enumSpec.values.forEach((propVal) => {
+          enumSpec.enum.forEach((propVal) => {
             if (propVal === null) {
               // our duplicate() method use JSON.stringify, parse and thus can accidentally
               // convert undefined in an array into null

--- a/src/enumspec.ts
+++ b/src/enumspec.ts
@@ -10,7 +10,7 @@ export const SHORT_ENUM_SPEC = ShortEnumSpec.ENUMSPEC;
 
 export interface EnumSpec<T> {
   name?: string;
-  values?: T[];
+  enum?: T[];
 }
 
 export interface ExtendedEnumSpec<T> extends EnumSpec<T> {
@@ -18,12 +18,12 @@ export interface ExtendedEnumSpec<T> extends EnumSpec<T> {
 }
 
 export function isEnumSpec(prop: any) {
-  return prop === SHORT_ENUM_SPEC || (prop !== undefined && (!!prop.values || !!prop.name) && !isArray(prop));
+  return prop === SHORT_ENUM_SPEC || (prop !== undefined && (!!prop.enum || !!prop.name) && !isArray(prop));
 }
 
 export function initEnumSpec(prop: any, defaultName: string, defaultEnumValues: any[]): ExtendedEnumSpec<any> {
   return extend({}, {
       name: defaultName,
-      values: defaultEnumValues
+      enum: defaultEnumValues
     }, prop === SHORT_ENUM_SPEC ? {} : prop);
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -226,11 +226,11 @@ export class SpecQueryModel {
       const countEncQ: EncodingQuery = {
         channel: {
           name: getDefaultName(Property.CHANNEL) + specQ.encodings.length,
-          values: getDefaultEnumValues(Property.CHANNEL, schema, opt)
+          enum: getDefaultEnumValues(Property.CHANNEL, schema, opt)
         },
         autoCount: {
           name: getDefaultName(Property.AUTOCOUNT) + specQ.encodings.length,
-          values: [false, true]
+          enum: [false, true]
         },
         type: Type.QUANTITATIVE
       };
@@ -313,7 +313,7 @@ export class SpecQueryModel {
     } else if (hasNestedProperty(prop) && value === true) {
       encQ[prop] = extend({},
         encQ[prop], // copy all existing properties
-        {values: undefined, name: undefined} // except name and values to it no longer an enumSpec
+        {enum: undefined, name: undefined} // except name and values to it no longer an enumSpec
       );
     } else { // encoding property (non-nested)
       encQ[prop] = value;

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -918,7 +918,7 @@ describe('constraints/spec', () => {
         mark: Mark.POINT,
         encodings: [
           {channel: Channel.X, aggregate: AggregateOp.MEAN, field: 'A', type: Type.NOMINAL},
-          {channel: Channel.Y, timeUnit: {values: [TimeUnit.MONTH, undefined]}, field: 'C', type: Type.TEMPORAL}
+          {channel: Channel.Y, timeUnit: {enum: [TimeUnit.MONTH, undefined]}, field: 'C', type: Type.TEMPORAL}
         ]
       });
 
@@ -954,7 +954,7 @@ describe('constraints/spec', () => {
         mark: Mark.POINT,
         encodings: [
           {channel: Channel.X, aggregate: AggregateOp.MEAN, field: 'A', type: Type.NOMINAL},
-          {channel: Channel.Y, bin: {values: [true, false]}, field: 'C', type: Type.QUANTITATIVE}
+          {channel: Channel.Y, bin: {enum: [true, false]}, field: 'C', type: Type.QUANTITATIVE}
         ]
       });
 
@@ -973,7 +973,7 @@ describe('constraints/spec', () => {
     });
 
     it('should return true for any raw plot', () => {
-      [TimeUnit.MONTH, undefined, {values: [TimeUnit.MONTH, undefined]}].forEach((timeUnit) => {
+      [TimeUnit.MONTH, undefined, {enum: [TimeUnit.MONTH, undefined]}].forEach((timeUnit) => {
         const specM = buildSpecQueryModel({
           mark: Mark.POINT,
           encodings: [
@@ -1029,7 +1029,7 @@ describe('constraints/spec', () => {
         mark: Mark.POINT,
         encodings: [
           {channel: Channel.X, field: 'A', type: Type.NOMINAL},
-          {channel: Channel.Y, field: {values: ['B']}, type: Type.NOMINAL}
+          {channel: Channel.Y, field: {enum: ['B']}, type: Type.NOMINAL}
         ]
       });
 

--- a/test/enumerator.test.ts
+++ b/test/enumerator.test.ts
@@ -25,7 +25,7 @@ describe('enumerator', () => {
   describe('mark', () => {
     it('should correctly enumerate marks', () => {
       const specM = buildSpecQueryModel({
-        mark: {values: [Mark.POINT, Mark.TICK]},
+        mark: {enum: [Mark.POINT, Mark.TICK]},
         encodings: [
           {channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
           {channel: Channel.Y, field: 'O', type: Type.ORDINAL}
@@ -41,7 +41,7 @@ describe('enumerator', () => {
 
     it('should not enumerate invalid mark', () => {
       const specM = buildSpecQueryModel({
-        mark: {values: [Mark.POINT, Mark.BAR, Mark.LINE, Mark.AREA]},
+        mark: {enum: [Mark.POINT, Mark.BAR, Mark.LINE, Mark.AREA]},
         encodings: [
           {channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
           {channel: Channel.SHAPE, field: 'O', type: Type.ORDINAL}
@@ -62,7 +62,7 @@ describe('enumerator', () => {
           mark: Mark.POINT,
           encodings: [
             {
-              channel: {values: [Channel.X, Channel.Y]},
+              channel: {enum: [Channel.X, Channel.Y]},
               field: 'Q',
               type: Type.QUANTITATIVE
             }
@@ -82,7 +82,7 @@ describe('enumerator', () => {
           mark: Mark.BAR,
           encodings: [
             {
-              channel: {values: [Channel.X, Channel.SHAPE]},
+              channel: {enum: [Channel.X, Channel.SHAPE]},
               field: 'Q',
               type: Type.QUANTITATIVE
             }
@@ -104,7 +104,7 @@ describe('enumerator', () => {
           encodings: [
             {
               channel: Channel.X,
-              aggregate: {values: [AggregateOp.MEAN, AggregateOp.MEDIAN, undefined]},
+              aggregate: {enum: [AggregateOp.MEAN, AggregateOp.MEDIAN, undefined]},
               field: 'Q',
               type: Type.QUANTITATIVE
             }
@@ -125,7 +125,7 @@ describe('enumerator', () => {
           encodings: [
             {
               channel: Channel.X,
-              aggregate: {values: [AggregateOp.MEAN, AggregateOp.MEDIAN, undefined]},
+              aggregate: {enum: [AggregateOp.MEAN, AggregateOp.MEDIAN, undefined]},
               field: 'N',
               type: Type.NOMINAL
             }
@@ -147,7 +147,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               bin: {
-                values: [true, false],
+                enum: [true, false],
                 maxbins: 10
               },
               field: 'Q',
@@ -170,7 +170,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               bin: {
-                values: [true, false]
+                enum: [true, false]
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -194,7 +194,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               bin: {
-                maxbins: {values: [5, 10, 20]}
+                maxbins: {enum: [5, 10, 20]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -219,7 +219,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                values: [true, false],
+                enum: [true, false],
                 type: ScaleType.LOG
               },
               field: 'Q',
@@ -242,7 +242,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                values: [true, false]
+                enum: [true, false]
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -266,7 +266,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                clamp: {values: [true, false, undefined]}
+                clamp: {enum: [true, false, undefined]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -291,7 +291,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                domain: {values: [undefined, ['cats', 'dogs'], ['chickens', 'pigs']]}
+                domain: {enum: [undefined, ['cats', 'dogs'], ['chickens', 'pigs']]}
               },
               field: 'N',
               type: Type.NOMINAL
@@ -314,7 +314,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                domain: {values: [undefined, [1,3], [5,7]]}
+                domain: {enum: [undefined, [1,3], [5,7]]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -339,7 +339,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                exponent: {values: [0.5, 1, 2, undefined]},
+                exponent: {enum: [0.5, 1, 2, undefined]},
                 type: ScaleType.LOG
               },
               field: 'Q',
@@ -367,7 +367,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                nice: {values: [undefined, true, false]}
+                nice: {enum: [undefined, true, false]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -389,7 +389,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                range: {values: [undefined, ['cats', 'dogs'], ['chickens', 'pigs']]}
+                range: {enum: [undefined, ['cats', 'dogs'], ['chickens', 'pigs']]}
               },
               field: 'N',
               type: Type.NOMINAL
@@ -412,7 +412,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                range: {values: [undefined, [1,3], [5,7]]}
+                range: {enum: [undefined, [1,3], [5,7]]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -437,7 +437,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                round: {values: [true, false, undefined]}
+                round: {enum: [true, false, undefined]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -462,7 +462,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                type: {values: [undefined, ScaleType.LOG, ScaleType.POW, ScaleType.ORDINAL]}
+                type: {enum: [undefined, ScaleType.LOG, ScaleType.POW, ScaleType.ORDINAL]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -487,7 +487,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               scale: {
-                useRawDomain: {values: [true, false, undefined]}
+                useRawDomain: {enum: [true, false, undefined]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -512,7 +512,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               field: 'Q',
-              timeUnit: {values: [TimeUnit.MONTH, TimeUnit.DAY, TimeUnit.YEAR, undefined]},
+              timeUnit: {enum: [TimeUnit.MONTH, TimeUnit.DAY, TimeUnit.YEAR, undefined]},
               type: Type.TEMPORAL
             }
           ]
@@ -534,7 +534,7 @@ describe('enumerator', () => {
             {
               channel: Channel.X,
               field: 'Q',
-              timeUnit: {values: [TimeUnit.MONTH, TimeUnit.DAY, TimeUnit.YEAR, undefined]},
+              timeUnit: {enum: [TimeUnit.MONTH, TimeUnit.DAY, TimeUnit.YEAR, undefined]},
               type: Type.QUANTITATIVE
             }
           ]
@@ -554,7 +554,7 @@ describe('enumerator', () => {
           encodings: [
             {
               channel: Channel.X,
-              field: {values: ['Q', 'Q1', 'Q2', 'O', 'N', 'T']},
+              field: {enum: ['Q', 'Q1', 'Q2', 'O', 'N', 'T']},
               type: Type.QUANTITATIVE
             }
           ]
@@ -574,7 +574,7 @@ describe('enumerator', () => {
           encodings: [
             {
               channel: Channel.X,
-              field: {values: ['T', 'Q', 'O', 'N']},
+              field: {enum: ['T', 'Q', 'O', 'N']},
               type: Type.TEMPORAL
             }
           ]
@@ -592,7 +592,7 @@ describe('enumerator', () => {
           encodings: [
             {
               channel: Channel.X,
-              field: {values: ['O', 'O_10', 'O_20', 'O_100', 'Q', 'T', 'N']},
+              field: {enum: ['O', 'O_10', 'O_20', 'O_100', 'Q', 'T', 'N']},
               type: Type.ORDINAL
             }
           ]
@@ -613,7 +613,7 @@ describe('enumerator', () => {
           encodings: [
             {
               channel: Channel.X,
-              field: {values: ['N', 'N20', 'Q', 'O', 'T']},
+              field: {enum: ['N', 'N20', 'Q', 'O', 'T']},
               type: Type.NOMINAL
             }
           ]
@@ -632,7 +632,7 @@ describe('enumerator', () => {
         const specM = buildSpecQueryModel({
           mark: Mark.POINT,
           encodings: [
-            {channel: Channel.X, field: 'Q', type:  {values: [Type.QUANTITATIVE, Type.NOMINAL, Type.ORDINAL, Type.TEMPORAL]}},
+            {channel: Channel.X, field: 'Q', type:  {enum: [Type.QUANTITATIVE, Type.NOMINAL, Type.ORDINAL, Type.TEMPORAL]}},
           ]
         });
         const noTypeMatchesSchema = extend({}, DEFAULT_QUERY_CONFIG, {typeMatchesSchemaType: false});
@@ -649,7 +649,7 @@ describe('enumerator', () => {
         const specM = buildSpecQueryModel({
           mark: Mark.POINT,
           encodings: [
-            {channel: Channel.X, field: 'Q', type:  {values: [Type.QUANTITATIVE, Type.NOMINAL, Type.ORDINAL, Type.TEMPORAL]}},
+            {channel: Channel.X, field: 'Q', type:  {enum: [Type.QUANTITATIVE, Type.NOMINAL, Type.ORDINAL, Type.TEMPORAL]}},
           ]
         });
         const enumerator = ENUMERATOR_INDEX[Property.TYPE](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
@@ -663,7 +663,7 @@ describe('enumerator', () => {
         const specM = buildSpecQueryModel({
           mark: Mark.POINT,
           encodings: [
-            {channel: Channel.X, field: 'O', type: {values: [Type.ORDINAL, Type.TEMPORAL, Type.QUANTITATIVE, Type.NOMINAL]}}
+            {channel: Channel.X, field: 'O', type: {enum: [Type.ORDINAL, Type.TEMPORAL, Type.QUANTITATIVE, Type.NOMINAL]}}
           ]
         });
         const enumerator = ENUMERATOR_INDEX[Property.TYPE](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
@@ -677,7 +677,7 @@ describe('enumerator', () => {
         const specM = buildSpecQueryModel({
           mark: Mark.POINT,
           encodings: [
-            {channel: Channel.X, field: 'T', type: {values:[Type.TEMPORAL, Type.ORDINAL, Type.QUANTITATIVE, Type.NOMINAL]}}
+            {channel: Channel.X, field: 'T', type: {enum:[Type.TEMPORAL, Type.ORDINAL, Type.QUANTITATIVE, Type.NOMINAL]}}
           ]
         });
         const enumerator = ENUMERATOR_INDEX[Property.TYPE](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);
@@ -691,7 +691,7 @@ describe('enumerator', () => {
         const specM = buildSpecQueryModel({
           mark: Mark.POINT,
           encodings: [
-            {channel: Channel.X, field: 'N', type: {values: [Type.NOMINAL, Type.TEMPORAL, Type.QUANTITATIVE, Type.ORDINAL]}}
+            {channel: Channel.X, field: 'N', type: {enum: [Type.NOMINAL, Type.TEMPORAL, Type.QUANTITATIVE, Type.ORDINAL]}}
           ]
         });
         const enumerator = ENUMERATOR_INDEX[Property.TYPE](specM.enumSpecIndex, schema, DEFAULT_QUERY_CONFIG);

--- a/test/enumspec.test.ts
+++ b/test/enumspec.test.ts
@@ -8,7 +8,7 @@ describe('enumspec', () => {
     it('should return true for an enum spec with name and values', () => {
       assert(isEnumSpec({
         name: 'a',
-        values: [1,2,3]
+        enum: [1,2,3]
       }));
     });
 
@@ -20,7 +20,7 @@ describe('enumspec', () => {
 
     it('should return true for an enum spec with values', () => {
       assert(isEnumSpec({
-        values: [1,2,3]
+        enum: [1,2,3]
       }));
     });
 
@@ -50,13 +50,13 @@ describe('enumspec', () => {
       const mark = initEnumSpec(SHORT_ENUM_SPEC, 'm', [Mark.POINT]);
       assert.deepEqual(mark, {
         name: 'm',
-        values: [Mark.POINT]
+        enum: [Mark.POINT]
       });
     });
 
     it('should return full enumSpec with other properties preserved', () => {
-      const binQuery = initEnumSpec({values: [true, false], maxbins: 30}, 'b1', [true, false]);
-      assert.deepEqual(binQuery.values, [true, false]);
+      const binQuery = initEnumSpec({enum: [true, false], maxbins: 30}, 'b1', [true, false]);
+      assert.deepEqual(binQuery.enum, [true, false]);
       assert.equal(binQuery['maxbins'], 30);
       assert.equal(binQuery.name, 'b1');
     });

--- a/test/enumspecindex.test.ts
+++ b/test/enumspecindex.test.ts
@@ -8,20 +8,20 @@ describe('enumspecindex', () => {
   describe('isEmpty', () => {
     it('should return false if encoding property is set', () => {
       let enumSpecIndex = new EnumSpecIndex()
-        .setEncodingProperty(0, Property.SCALE, {name: 'scale', values: [true, false]});
+        .setEncodingProperty(0, Property.SCALE, {name: 'scale', enum: [true, false]});
       assert.equal(enumSpecIndex.isEmpty(), false);
     });
 
     it('should return false if mark is set', () => {
       let enumSpecIndex = new EnumSpecIndex()
-        .setMark({name: 'mark', values: [Mark.POINT, Mark.BAR, Mark.LINE]});
+        .setMark({name: 'mark', enum: [Mark.POINT, Mark.BAR, Mark.LINE]});
       assert.equal(enumSpecIndex.isEmpty(), false);
     });
 
     it('should return false if mark and encoding property are set', () => {
       let enumSpecIndex = new EnumSpecIndex()
-        .setEncodingProperty(0, Property.SCALE, {name: 'scale', values: [true, false]})
-        .setMark({name: 'mark', values: [Mark.POINT, Mark.BAR, Mark.LINE]});
+        .setEncodingProperty(0, Property.SCALE, {name: 'scale', enum: [true, false]})
+        .setMark({name: 'mark', enum: [Mark.POINT, Mark.BAR, Mark.LINE]});
       assert.equal(enumSpecIndex.isEmpty(), false);
     });
 
@@ -34,7 +34,7 @@ describe('enumspecindex', () => {
   describe('hasProperty', () => {
     it('should return true if encodingIndicesByProperty contains a specified encoding property', () => {
       let enumSpecIndex = new EnumSpecIndex()
-        .setEncodingProperty(0, Property.SCALE, {name: 'scale', values: [true, false]});
+        .setEncodingProperty(0, Property.SCALE, {name: 'scale', enum: [true, false]});
       assert.equal(enumSpecIndex.hasProperty(Property.SCALE), true);
     });
 
@@ -45,7 +45,7 @@ describe('enumspecindex', () => {
 
     it('should return true if enumSpecIndex contains Property.MARK when Property.MARK is specified', () => {
       let enumSpecIndex = new EnumSpecIndex()
-        .setMark({name: 'mark', values: [Mark.POINT, Mark.BAR, Mark.LINE]});
+        .setMark({name: 'mark', enum: [Mark.POINT, Mark.BAR, Mark.LINE]});
       assert.equal(enumSpecIndex.hasProperty(Property.MARK), true);
     });
 

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -43,7 +43,7 @@ describe('generate', function () {
         const specQ = {
           mark: Mark.POINT,
           encodings: [
-            {aggregate: {name: 'aggregate', values: [undefined, AggregateOp.MEAN]}, channel: Channel.X, field: 'A', type: Type.QUANTITATIVE},
+            {aggregate: {name: 'aggregate', enum: [undefined, AggregateOp.MEAN]}, channel: Channel.X, field: 'A', type: Type.QUANTITATIVE},
           ],
         };
         const CONFIG_WITH_OMIT_AGGREGATE = extend({}, DEFAULT_QUERY_CONFIG, {omitAggregate: true});
@@ -60,7 +60,7 @@ describe('generate', function () {
         const specQ = {
           mark: Mark.POINT,
           encodings: [
-            {aggregate: {name:'aggregate', values: [undefined, AggregateOp.MEAN]}, channel: Channel.X, field: 'A', type: Type.QUANTITATIVE},
+            {aggregate: {name:'aggregate', enum: [undefined, AggregateOp.MEAN]}, channel: Channel.X, field: 'A', type: Type.QUANTITATIVE},
           ]
         };
         const CONFIG_WITH_OMIT_RAW = extend({}, DEFAULT_QUERY_CONFIG, {omitRaw: true});
@@ -219,7 +219,7 @@ describe('generate', function () {
             channel: Channel.X,
             scale: {
               bandSize: 10,
-              type: {values: [undefined, ScaleType.LOG, ScaleType.TIME, ScaleType.ORDINAL]}
+              type: {enum: [undefined, ScaleType.LOG, ScaleType.TIME, ScaleType.ORDINAL]}
             },
             field: 'Q',
             type: Type.NOMINAL
@@ -243,7 +243,7 @@ describe('generate', function () {
             scale: {
               clamp: true,
               exponent: [1,2],
-              type: {values: [undefined, ScaleType.LINEAR, ScaleType.LOG, ScaleType.ORDINAL,
+              type: {enum: [undefined, ScaleType.LINEAR, ScaleType.LOG, ScaleType.ORDINAL,
                               ScaleType.POW, ScaleType.QUANTILE, ScaleType.QUANTIZE, ScaleType.SQRT,
                               ScaleType.TIME, ScaleType.UTC]}
             },
@@ -269,7 +269,7 @@ describe('generate', function () {
             scale: {
               nice: true,
               round: true,
-              type: {values: [undefined, ScaleType.LINEAR, ScaleType.LOG, ScaleType.ORDINAL,
+              type: {enum: [undefined, ScaleType.LINEAR, ScaleType.LOG, ScaleType.ORDINAL,
                               ScaleType.POW, ScaleType.QUANTILE, ScaleType.QUANTIZE, ScaleType.SQRT,
                               ScaleType.TIME, ScaleType.UTC]}
             },
@@ -296,7 +296,7 @@ describe('generate', function () {
             channel: Channel.X,
             scale: {
               zero: true,
-              type: {values: [undefined, ScaleType.SQRT, ScaleType.LOG, ScaleType.ORDINAL, ScaleType.TIME, ScaleType.UTC]}
+              type: {enum: [undefined, ScaleType.SQRT, ScaleType.LOG, ScaleType.ORDINAL, ScaleType.TIME, ScaleType.UTC]}
             },
             field: 'Q',
             type: Type.QUANTITATIVE
@@ -317,7 +317,7 @@ describe('generate', function () {
             channel: Channel.X,
             scale: {
               zero: true,
-              type: {values: [undefined, ScaleType.SQRT, ScaleType.LOG, ScaleType.ORDINAL, ScaleType.TIME, ScaleType.UTC]}
+              type: {enum: [undefined, ScaleType.SQRT, ScaleType.LOG, ScaleType.ORDINAL, ScaleType.TIME, ScaleType.UTC]}
             },
             field: 'Q',
             type: Type.QUANTITATIVE
@@ -339,7 +339,7 @@ describe('generate', function () {
             channel: Channel.X,
             scale: {
               zero: true,
-              type: {values: [undefined, ScaleType.SQRT, ScaleType.LOG, ScaleType.ORDINAL, ScaleType.TIME, ScaleType.UTC]}
+              type: {enum: [undefined, ScaleType.SQRT, ScaleType.LOG, ScaleType.ORDINAL, ScaleType.TIME, ScaleType.UTC]}
             },
             field: 'Q',
             type: Type.QUANTITATIVE
@@ -366,7 +366,7 @@ describe('generate', function () {
             channel: Channel.X,
             scale: {
               zero: true,
-              type: {values: [undefined, ScaleType.SQRT, ScaleType.LOG, ScaleType.ORDINAL, ScaleType.TIME, ScaleType.UTC]}
+              type: {enum: [undefined, ScaleType.SQRT, ScaleType.LOG, ScaleType.ORDINAL, ScaleType.TIME, ScaleType.UTC]}
             },
             field: 'Q',
             type: Type.QUANTITATIVE
@@ -387,8 +387,8 @@ describe('generate', function () {
           {
             channel: Channel.X,
             scale: {
-              values: [true, false],
-              type: {values: [undefined, ScaleType.LOG, ScaleType.UTC]}
+              enum: [true, false],
+              type: {enum: [undefined, ScaleType.LOG, ScaleType.UTC]}
             },
             field: 'Q',
             type: Type.QUANTITATIVE
@@ -409,7 +409,7 @@ describe('generate', function () {
         encodings: [
           {
             channel: Channel.X,
-            scale: {type: {values: [undefined, ScaleType.LOG, ScaleType.UTC]}},
+            scale: {type: {enum: [undefined, ScaleType.LOG, ScaleType.UTC]}},
             field: 'Q',
             type: Type.QUANTITATIVE
           }
@@ -428,7 +428,7 @@ describe('generate', function () {
         encodings: [
           {
             channel: Channel.X,
-            scale: {type: {values: [ScaleType.TIME, ScaleType.UTC, ScaleType.ORDINAL, undefined, ScaleType.LOG]}},
+            scale: {type: {enum: [ScaleType.TIME, ScaleType.UTC, ScaleType.ORDINAL, undefined, ScaleType.LOG]}},
             field: 'T',
             type: Type.TEMPORAL
           }
@@ -448,7 +448,7 @@ describe('generate', function () {
         encodings: [
           {
             channel: Channel.X,
-            scale: {type: {values: [ScaleType.TIME, ScaleType.UTC, ScaleType.ORDINAL, undefined, ScaleType.LOG]}},
+            scale: {type: {enum: [ScaleType.TIME, ScaleType.UTC, ScaleType.ORDINAL, undefined, ScaleType.LOG]}},
             field: 'T',
             type: Type.TEMPORAL,
             timeUnit: TimeUnit.MINUTES
@@ -470,7 +470,7 @@ describe('generate', function () {
         encodings: [
           {
             channel: Channel.X,
-            scale: {type: {values: [ScaleType.ORDINAL, undefined, ScaleType.LOG]}},
+            scale: {type: {enum: [ScaleType.ORDINAL, undefined, ScaleType.LOG]}},
             field: 'O',
             type: Type.ORDINAL,
             timeUnit: TimeUnit.MINUTES
@@ -490,7 +490,7 @@ describe('generate', function () {
         encodings: [
           {
             channel: Channel.X,
-            scale: {type: {values: [ScaleType.ORDINAL, ScaleType.QUANTILE, undefined, ScaleType.LOG]}},
+            scale: {type: {enum: [ScaleType.ORDINAL, ScaleType.QUANTILE, undefined, ScaleType.LOG]}},
             field: 'O',
             type: Type.ORDINAL
           }
@@ -509,7 +509,7 @@ describe('generate', function () {
         encodings: [
           {
             channel: Channel.X,
-            scale: {type: {values: [undefined, ScaleType.LOG]}},
+            scale: {type: {enum: [undefined, ScaleType.LOG]}},
             field: 'N',
             type: Type.NOMINAL
           }
@@ -530,7 +530,7 @@ describe('generate', function () {
           encodings: [
             {
               channel: Channel.X,
-              bin: {maxbins: {values: [10, 20, 30]}},
+              bin: {maxbins: {enum: [10, 20, 30]}},
               field: 'Q',
               type: Type.QUANTITATIVE
             }
@@ -551,8 +551,8 @@ describe('generate', function () {
             {
               channel: Channel.X,
               bin: {
-                values: [true, false],
-                maxbins: {values: [10, 20, 30]}
+                enum: [true, false],
+                maxbins: {enum: [10, 20, 30]}
               },
               field: 'Q',
               type: Type.QUANTITATIVE
@@ -608,7 +608,7 @@ describe('generate', function () {
         mark: Mark.POINT,
         encodings: [
           {
-            channel: {values: [Channel.X, Channel.SIZE, Channel.COLOR]},
+            channel: {enum: [Channel.X, Channel.SIZE, Channel.COLOR]},
             field: 'Q',
             type: Type.QUANTITATIVE
           }

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -44,21 +44,21 @@ describe('SpecQueryModel', () => {
       const enumSpecIndex = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG).enumSpecIndex;
       assert.deepEqual(enumSpecIndex.mark, {
         name: 'm',
-        values: DEFAULT_QUERY_CONFIG.marks
+        enum: DEFAULT_QUERY_CONFIG.marks
       });
     });
 
     it('should have mark enumSpecIndex if mark is an EnumSpec.', () => {
       const specQ: SpecQuery = {
         mark: {
-          values: [Mark.BAR]
+          enum: [Mark.BAR]
         },
         encodings: []
       };
       const enumSpecIndex = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG).enumSpecIndex;
       assert.deepEqual(enumSpecIndex.mark, {
         name: 'm',
-        values: [Mark.BAR]
+        enum: [Mark.BAR]
       });
     });
 
@@ -116,7 +116,7 @@ describe('SpecQueryModel', () => {
           ['A', 'B'] :
           getDefaultEnumValues(prop, schema, DEFAULT_QUERY_CONFIG);
         specQ.encodings[0][prop] = {
-          values: enumValues
+          enum: enumValues
         };
 
         const enumSpecIndex = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG).enumSpecIndex;
@@ -154,7 +154,7 @@ describe('SpecQueryModel', () => {
         let specQ = duplicate(templateSpecQ);
         specQ.encodings[0][parent] = {};
         specQ.encodings[0][parent][child] = {
-          values: getDefaultEnumValues(prop, schema, DEFAULT_QUERY_CONFIG)
+          enum: getDefaultEnumValues(prop, schema, DEFAULT_QUERY_CONFIG)
         };
 
         const enumSpecIndex = SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG).enumSpecIndex;
@@ -407,7 +407,7 @@ describe('SpecQueryModel', () => {
 
     it('should return null if the query is incompleted', () => {
       const specM = buildSpecQueryModel({
-        mark: {values: [Mark.BAR, Mark.POINT]},
+        mark: {enum: [Mark.BAR, Mark.POINT]},
         encodings: [
           {channel: Channel.X, field: 'A', type: Type.QUANTITATIVE}
         ],

--- a/test/nest.test.ts
+++ b/test/nest.test.ts
@@ -30,7 +30,7 @@ describe('nest', () => {
               type: Type.QUANTITATIVE,
               aggregate: {
                 name: 'a0',
-                values: [AggregateOp.MEAN, AggregateOp.MEDIAN]
+                enum: [AggregateOp.MEAN, AggregateOp.MEDIAN]
               }
             }, {
               channel: SHORT_ENUM_SPEC,
@@ -128,7 +128,7 @@ describe('nest', () => {
             type: Type.QUANTITATIVE,
             aggregate: {
               name: 'a0',
-              values: [AggregateOp.MEAN, AggregateOp.MEDIAN]
+              enum: [AggregateOp.MEAN, AggregateOp.MEDIAN]
             }
           }, {
             channel: SHORT_ENUM_SPEC,
@@ -173,7 +173,7 @@ describe('nest', () => {
             field: 'Q1',
             type: Type.QUANTITATIVE
           }, {
-            channel: {values: [Channel.COLOR, Channel.SIZE]},
+            channel: {enum: [Channel.COLOR, Channel.SIZE]},
             field: 'Q2',
             type: Type.QUANTITATIVE
           }]
@@ -210,7 +210,7 @@ describe('nest', () => {
             field: 'Q1',
             type: Type.QUANTITATIVE
           }, {
-            channel: {values: [Channel.COLOR, Channel.SHAPE]},
+            channel: {enum: [Channel.COLOR, Channel.SHAPE]},
             field: 'O',
             type: Type.ORDINAL
           }]
@@ -239,15 +239,15 @@ describe('nest', () => {
         spec: {
           mark: SHORT_ENUM_SPEC,
           encodings: [{
-            channel: {values: [Channel.X, Channel.Y]},
+            channel: {enum: [Channel.X, Channel.Y]},
             field: 'Q',
             type: Type.QUANTITATIVE
           }, {
-            channel: {values: [Channel.X, Channel.Y]},
+            channel: {enum: [Channel.X, Channel.Y]},
             field: 'Q1',
             type: Type.QUANTITATIVE
           }, {
-            channel: {values: [Channel.COLOR, Channel.SIZE]},
+            channel: {enum: [Channel.COLOR, Channel.SIZE]},
             field: 'Q2',
             type: Type.QUANTITATIVE
           }]
@@ -381,7 +381,7 @@ describe('nest', () => {
             type: Type.QUANTITATIVE,
             aggregate: {
               name: 'a0',
-              values: [AggregateOp.MEAN, AggregateOp.MEDIAN]
+              enum: [AggregateOp.MEAN, AggregateOp.MEDIAN]
             }
           }, {
             channel: SHORT_ENUM_SPEC,
@@ -438,7 +438,7 @@ describe('nest', () => {
             type: Type.QUANTITATIVE,
             aggregate: {
               name: 'a0',
-              values: [AggregateOp.MEAN, AggregateOp.MEDIAN]
+              enum: [AggregateOp.MEAN, AggregateOp.MEDIAN]
             }
           }, {
             channel: SHORT_ENUM_SPEC,
@@ -474,7 +474,7 @@ describe('nest', () => {
             field: 'Q1',
             type: Type.QUANTITATIVE
           }, {
-            channel: {values: [Channel.COLOR, Channel.SIZE]},
+            channel: {enum: [Channel.COLOR, Channel.SIZE]},
             field: 'Q2',
             type: Type.QUANTITATIVE
           }]
@@ -501,7 +501,7 @@ describe('nest', () => {
             field: 'Q1',
             type: Type.QUANTITATIVE
           }, {
-            channel: {values: [Channel.COLOR, Channel.SHAPE]},
+            channel: {enum: [Channel.COLOR, Channel.SHAPE]},
             field: 'O',
             type: Type.ORDINAL
           }]
@@ -520,15 +520,15 @@ describe('nest', () => {
         spec: {
           mark: SHORT_ENUM_SPEC,
           encodings: [{
-            channel: {values: [Channel.X, Channel.Y]},
+            channel: {enum: [Channel.X, Channel.Y]},
             field: 'Q',
             type: Type.QUANTITATIVE
           }, {
-            channel: {values: [Channel.X, Channel.Y]},
+            channel: {enum: [Channel.X, Channel.Y]},
             field: 'Q1',
             type: Type.QUANTITATIVE
           }, {
-            channel: {values: [Channel.COLOR, Channel.SIZE]},
+            channel: {enum: [Channel.COLOR, Channel.SIZE]},
             field: 'Q2',
             type: Type.QUANTITATIVE
           }]
@@ -624,11 +624,11 @@ describe('nest', () => {
           spec: {
             mark: SHORT_ENUM_SPEC,
             encodings: [{
-              channel: {values: [Channel.X, Channel.Y]},
+              channel: {enum: [Channel.X, Channel.Y]},
               field: 'Q',
               type: Type.QUANTITATIVE
             }, {
-              channel: {values: [Channel.X, Channel.Y]},
+              channel: {enum: [Channel.X, Channel.Y]},
               field: 'Q2',
               type: Type.QUANTITATIVE
             }]
@@ -655,11 +655,11 @@ describe('nest', () => {
               field: 'Q1',
               type: Type.QUANTITATIVE
             }, {
-              channel: {values: [Channel.ROW, Channel.COLUMN]},
+              channel: {enum: [Channel.ROW, Channel.COLUMN]},
               field: 'O',
               type: Type.ORDINAL
             }, {
-              channel: {values: [Channel.ROW, Channel.COLUMN]},
+              channel: {enum: [Channel.ROW, Channel.COLUMN]},
               field: 'N',
               type: Type.NOMINAL
             }]
@@ -683,7 +683,7 @@ describe('nest', () => {
               field: 'Q',
               type: Type.QUANTITATIVE
             }, {
-              channel: {values: [Channel.Y, Channel.COLOR]},
+              channel: {enum: [Channel.Y, Channel.COLOR]},
               field: 'Q1',
               type: Type.QUANTITATIVE
             }]
@@ -705,15 +705,15 @@ describe('nest', () => {
         spec: {
           mark: Mark.POINT,
           encodings: [{
-            channel: {values: [Channel.X, Channel.Y]},
+            channel: {enum: [Channel.X, Channel.Y]},
             field: 'Q',
             type: Type.QUANTITATIVE,
             aggregate: {
               name: 'a0',
-              values: [AggregateOp.MEAN, AggregateOp.MEDIAN]
+              enum: [AggregateOp.MEAN, AggregateOp.MEDIAN]
             }
           }, {
-            channel: {values: [Channel.X, Channel.Y]},
+            channel: {enum: [Channel.X, Channel.Y]},
             field: 'O',
             type: Type.ORDINAL
           }]

--- a/test/stylize.test.ts
+++ b/test/stylize.test.ts
@@ -91,7 +91,7 @@ describe('stylize', () => {
         let specM = SpecQueryModel.build({
             mark: Mark.BAR,
             encodings: [
-              {channel: Channel.Y, field: 'O_100', scale: {name: 'scale', values: [true, false]}, type: Type.ORDINAL}
+              {channel: Channel.Y, field: 'O_100', scale: {name: 'scale', enum: [true, false]}, type: Type.ORDINAL}
             ]
           }, schema, DEFAULT_QUERY_CONFIG);
 
@@ -103,12 +103,12 @@ describe('stylize', () => {
       let specM = SpecQueryModel.build({
           mark: Mark.BAR,
           encodings: [
-            {channel: Channel.Y, field: 'O_100', scale: {bandSize: {name: 'scaleBandSize', values: [17, 21]}}, type: Type.ORDINAL}
+            {channel: Channel.Y, field: 'O_100', scale: {bandSize: {name: 'scaleBandSize', enum: [17, 21]}}, type: Type.ORDINAL}
           ]
         }, schema, DEFAULT_QUERY_CONFIG);
 
       specM = smallBandSizeForHighCardinalityOrFacet(specM, schema);
-      assert.deepEqual((specM.getEncodingQueryByChannel(Channel.Y).scale as ScaleQuery).bandSize, {name: 'scaleBandSize', values: [17, 21]});
+      assert.deepEqual((specM.getEncodingQueryByChannel(Channel.Y).scale as ScaleQuery).bandSize, {name: 'scaleBandSize', enum: [17, 21]});
     });
   });
 
@@ -165,7 +165,7 @@ describe('stylize', () => {
         let specM = SpecQueryModel.build({
             mark: Mark.POINT,
             encodings: [
-              {channel: Channel.COLOR, field: 'N20', scale: {name: 'scale', values: [true, false]}, type: Type.NOMINAL}
+              {channel: Channel.COLOR, field: 'N20', scale: {name: 'scale', enum: [true, false]}, type: Type.NOMINAL}
             ]
           }, schema, DEFAULT_QUERY_CONFIG);
 
@@ -177,12 +177,12 @@ describe('stylize', () => {
         let specM = SpecQueryModel.build({
             mark: Mark.POINT,
             encodings: [
-              {channel: Channel.COLOR, field: 'N20', scale: {range: {name: 'scaleRange', values: [null]}}, type: Type.NOMINAL}
+              {channel: Channel.COLOR, field: 'N20', scale: {range: {name: 'scaleRange', enum: [null]}}, type: Type.NOMINAL}
             ]
           }, schema, DEFAULT_QUERY_CONFIG);
 
         specM = nominalColorScaleForHighCardinality(specM, schema);
-        assert.deepEqual((specM.getEncodingQueryByChannel(Channel.COLOR).scale as ScaleQuery).range, {name: 'scaleRange', values: [null]});
+        assert.deepEqual((specM.getEncodingQueryByChannel(Channel.COLOR).scale as ScaleQuery).range, {name: 'scaleRange', enum: [null]});
     });
   });
 });


### PR DESCRIPTION
Rename EnumSpec's `values` to `enum` so it does not conflict with Axis' values property.
