### PR TITLE
Refactor `scaleType` to take `encQ` as input

### DIFF
--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -168,11 +168,12 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
          //  to scale type is EnumSpec. If scale type is an EnumSpec, we do not yet know
          //  what the scale type is, and thus can ignore the constraint.
 
-        if ((scale.type === undefined && isEnumSpec(encQ.type)) || isEnumSpec(scale.type)) {
+        const sType = scaleType(encQ);
+
+        if (sType === undefined) {
+          // If still ambiguous, doesn't check the constraint
           return true;
         }
-
-        const sType = scaleType(scale.type, encQ.timeUnit, encQ.type);
 
         for (let scaleProp in scale) {
           if (SUPPORTED_SCALE_PROPERTY_INDEX[scaleProp]) {
@@ -267,7 +268,7 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
     satisfy: (encQ: EncodingQuery, schema: Schema, opt: QueryConfig) => {
       if (encQ.scale) {
         const type = encQ.type;
-        const sType = scaleType((encQ.scale as ScaleQuery).type, encQ.timeUnit, type);
+        const sType = scaleType(encQ);
 
         if (contains([Type.ORDINAL, Type.NOMINAL], type)) {
             return contains([ScaleType.ORDINAL, undefined], sType);

--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -337,8 +337,7 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
         for (let encQ of encodings) {
           if((encQ.channel === Channel.X || encQ.channel === Channel.Y) && encQ.scale) {
 
-            let sType = scaleType((encQ.scale as ScaleQuery).type,
-                                  encQ.timeUnit, encQ.type);
+            let sType = scaleType(encQ);
 
             if (sType === ScaleType.LOG) {
               return false;

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -5,7 +5,7 @@ import {SortOrder, SortField} from 'vega-lite/src/sort';
 import {defaultScaleType, TimeUnit} from 'vega-lite/src/timeunit';
 import {Type} from 'vega-lite/src/type';
 
-import {EnumSpec, isEnumSpec, ShortEnumSpec} from '../enumspec';
+import {EnumSpec, isEnumSpec, ShortEnumSpec, SHORT_ENUM_SPEC} from '../enumspec';
 import {contains} from '../util';
 
 export type Field = string;
@@ -68,13 +68,14 @@ export function isMeasure(encQ: EncodingQuery) {
  *  @returns {undefined} If the scale type was not specified and Type (or TimeUnit if applicable) is an EnumSpec, there is no clear scale type
  */
 
-export function scaleType(scaleType: ScaleType | EnumSpec<ScaleType> | ShortEnumSpec,
-    timeUnit: TimeUnit | EnumSpec<TimeUnit> | ShortEnumSpec,
-    type: Type | EnumSpec<Type> | ShortEnumSpec) {
-  if (scaleType !== undefined) {
-    return scaleType;
-  }
+export function scaleType(encQ: EncodingQuery) {
+  const scale: ScaleQuery = encQ.scale === true || encQ.scale === SHORT_ENUM_SPEC ? {} : encQ.scale;
+  const type = encQ.type;
+  const timeUnit = encQ.timeUnit;
 
+  if (scale && scale.type !== undefined) {
+    return scale.type;
+  }
   if (isEnumSpec(type)) {
     return undefined;
   }

--- a/src/stylize.ts
+++ b/src/stylize.ts
@@ -46,7 +46,7 @@ export function smallBandSizeForHighCardinalityOrFacet(specM: SpecQueryModel, sc
 
       // We do not want to assign a bandSize if scale is set to false
       // and we only apply this if the scale is (or can be) an ordinal scale.
-      if (yEncQ.scale && contains([ScaleType.ORDINAL, undefined], scaleType((yEncQ.scale as ScaleQuery).type, yEncQ.timeUnit, yEncQ.type))) {
+      if (yEncQ.scale && contains([ScaleType.ORDINAL, undefined], scaleType(yEncQ))) {
         if (!(yEncQ.scale as ScaleQuery).bandSize) {
           (yEncQ.scale as ScaleQuery).bandSize = 12;
         }
@@ -66,7 +66,7 @@ export function smallBandSizeForHighCardinalityOrFacet(specM: SpecQueryModel, sc
 
       // We do not want to assign a bandSize if scale is set to false
       // and we only apply this if the scale is (or can be) an ordinal scale.
-      if (xEncQ.scale && contains([ScaleType.ORDINAL, undefined], scaleType((xEncQ.scale as ScaleQuery).type, xEncQ.timeUnit, xEncQ.type))) {
+      if (xEncQ.scale && contains([ScaleType.ORDINAL, undefined], scaleType(xEncQ))) {
         if (!(xEncQ.scale as ScaleQuery).bandSize) {
           (xEncQ.scale as ScaleQuery).bandSize = 12;
         }

--- a/test/query/encoding.test.ts
+++ b/test/query/encoding.test.ts
@@ -8,40 +8,64 @@
 
   describe('scaleType', () => {
     it('should return specified as scale type', () => {
-      const sType = scaleType(ScaleType.LINEAR, undefined, undefined);
+      const sType = scaleType({
+        channel: SHORT_ENUM_SPEC,
+        scale: {type: ScaleType.LINEAR},
+        type: SHORT_ENUM_SPEC
+      });
       assert.equal(sType, ScaleType.LINEAR);
     });
 
     it('should return undefined if scale type is not specified and type is an EnumSpec', () => {
-      const sType = scaleType(undefined, undefined, SHORT_ENUM_SPEC);
+      const sType = scaleType({
+        channel: SHORT_ENUM_SPEC,
+        type: SHORT_ENUM_SPEC
+      });
       assert.equal(sType, undefined);
     });
 
     it('should return ScaleType.LINEAR if type is quantitative and scale type is not specified', () => {
-      const sType = scaleType(undefined, undefined, Type.QUANTITATIVE);
+      const sType = scaleType({
+        channel: SHORT_ENUM_SPEC,
+        type: Type.QUANTITATIVE
+      });
       assert.equal(sType, ScaleType.LINEAR);
     });
 
     [Type.ORDINAL, Type.NOMINAL].forEach((type) => {
       it('should return ScaleType.ORDINAL if type is ' + type + ' and scale type is not specified', () => {
-        const sType = scaleType(undefined, undefined, type);
+        const sType = scaleType({
+          channel: SHORT_ENUM_SPEC,
+          type: type
+        });
         assert.equal(sType, ScaleType.ORDINAL);
       });
     });
 
     it('should return undefined if scale type is not specified, type is temporal, and TimeUnit is an EnumSpec', () => {
-      const sType = scaleType(undefined, SHORT_ENUM_SPEC, Type.TEMPORAL);
+      const sType = scaleType({
+        channel: SHORT_ENUM_SPEC,
+        timeUnit: SHORT_ENUM_SPEC,
+        type: Type.TEMPORAL
+      });
       assert.equal(sType, undefined);
     });
 
     it('should return ScaleType.TIME if type is temporal and scale type and TimeUnit are not specified', () => {
-      const sType = scaleType(undefined, undefined, Type.TEMPORAL);
+      const sType = scaleType({
+        channel: SHORT_ENUM_SPEC,
+        type: Type.TEMPORAL
+      });
       assert.equal(sType, ScaleType.TIME);
     });
 
     [TimeUnit.HOURS, TimeUnit.DAY, TimeUnit.MONTH, TimeUnit.QUARTER].forEach((timeUnit) => {
       it('should return ScaleType.ORDINAL if type is temporal and TimeUnit is ' + timeUnit + ' and scale type is not specified', () => {
-        const sType = scaleType(undefined, timeUnit, Type.TEMPORAL);
+        const sType = scaleType({
+          channel: SHORT_ENUM_SPEC,
+          timeUnit: timeUnit,
+          type: Type.TEMPORAL
+        });
         assert.equal(sType, ScaleType.ORDINAL);
       });
     });
@@ -51,13 +75,20 @@
      TimeUnit.HOURSMINUTES, TimeUnit.HOURSMINUTESSECONDS, TimeUnit.MINUTESSECONDS, TimeUnit.SECONDSMILLISECONDS,
      TimeUnit.YEARQUARTER, TimeUnit.QUARTERMONTH, TimeUnit.YEARQUARTERMONTH].forEach((timeUnit) => {
        it('should return ScaleType.TIME if type is temporal and TimeUnit is ' + timeUnit + ' and scale type is not specified', () => {
-         const sType = scaleType(undefined, timeUnit, Type.TEMPORAL);
+         const sType = scaleType({
+          channel: SHORT_ENUM_SPEC,
+          timeUnit: timeUnit,
+          type: Type.TEMPORAL
+         });
          assert.equal(sType, ScaleType.TIME);
        });
      });
 
      it('should return ScaleType.TIME if type is temporal, TimeUnit is undefined, and scale type is not defined', () => {
-       const sType = scaleType(undefined, undefined, Type.TEMPORAL);
+       const sType = scaleType({
+         channel: SHORT_ENUM_SPEC,
+         type: Type.TEMPORAL
+       });
        assert.equal(sType, ScaleType.TIME);
      });
   });


### PR DESCRIPTION
Since it's a method in `query/encoding`, refactor `scaleType` to take `encQ` as input.

This will simplify a lot of method call.  

