### PR TITLE
Prevent outputting inapplicable `scale`, `sort`, `axis`, `legend` from `toSpec()` and Shorthand

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -14,7 +14,7 @@ import {EnumSpecIndex} from './enumspecindex';
 import {SpecQuery, isAggregate, stack} from './query/spec';
 import {isDimension, isMeasure, EncodingQuery} from './query/encoding';
 import {GroupBy} from './query/groupby';
-import {spec as specShorthand} from './query/shorthand';
+import {spec as specShorthand, CHANNEL_SUPPORTS_AXIS, CHANNEL_SUPPORTS_LEGEND, CHANNEL_SUPPORTS_SCALE, CHANNEL_SUPPORTS_SORT} from './query/shorthand';
 import {RankingScore} from './ranking/ranking';
 import {Schema} from './schema';
 import {Dict, duplicate, extend} from './util';
@@ -694,7 +694,25 @@ export class SpecQueryModel {
 
         // otherwise, assign the proper to the field def
         if (encQ[prop] !== undefined) {
-          fieldDef[prop] = encQ[prop];
+          if (prop === Property.AXIS && !isEnumSpec(encQ.channel)) {
+            if (CHANNEL_SUPPORTS_AXIS[encQ.channel as Channel]) {
+              fieldDef[Property.AXIS] = encQ[Property.AXIS];
+            }
+          } else if (prop === Property.LEGEND && !isEnumSpec(encQ.channel)) {
+            if (CHANNEL_SUPPORTS_LEGEND[encQ.channel as Channel]) {
+              fieldDef[Property.LEGEND] = encQ[Property.LEGEND];
+            }
+          } else if (prop === Property.SCALE && !isEnumSpec(encQ.channel)) {
+            if (CHANNEL_SUPPORTS_SCALE[encQ.channel as Channel]) {
+              fieldDef[Property.SCALE] = encQ[Property.SCALE];
+            }
+          } else if (prop === Property.SORT && !isEnumSpec(encQ.channel)) {
+            if (CHANNEL_SUPPORTS_SORT[encQ.channel as Channel]) {
+              fieldDef[Property.SORT] = encQ[Property.SORT];
+            }
+          } else {
+            fieldDef[prop] = encQ[prop];
+          }
         }
       }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -695,9 +695,10 @@ export class SpecQueryModel {
         // otherwise, assign the proper to the field def
         if (encQ[prop] !== undefined) {
 
-          // We only output axis, legend, scale, or sort that have correct supporting channel
+          // axis, legend, scale, and sort only support certain channels
           let propNeedsToCheckChannel: boolean = contains([Property.AXIS, Property.LEGEND, Property.SCALE, Property.SORT], prop);
 
+          // We only output axis, legend, scale, or sort that have correct supporting channel
           if ((propNeedsToCheckChannel && !isEnumSpec(encQ.channel) && PROPERTY_SUPPORTED_CHANNELS[prop][encQ.channel as Channel]) ||
               !propNeedsToCheckChannel) {
             fieldDef[prop] = encQ[prop];

--- a/src/model.ts
+++ b/src/model.ts
@@ -17,7 +17,7 @@ import {GroupBy} from './query/groupby';
 import {spec as specShorthand, PROPERTY_SUPPORTED_CHANNELS} from './query/shorthand';
 import {RankingScore} from './ranking/ranking';
 import {Schema} from './schema';
-import {contains, Dict, duplicate, extend} from './util';
+import {Dict, duplicate, extend} from './util';
 
 export function getDefaultName(prop: Property) {
   switch (prop) {
@@ -695,12 +695,8 @@ export class SpecQueryModel {
         // otherwise, assign the proper to the field def
         if (encQ[prop] !== undefined) {
 
-          // axis, legend, scale, and sort only support certain channels
-          let propNeedsToCheckChannel: boolean = contains([Property.AXIS, Property.LEGEND, Property.SCALE, Property.SORT], prop);
-
-          // We only output axis, legend, scale, or sort that have correct supporting channel
-          if ((propNeedsToCheckChannel && !isEnumSpec(encQ.channel) && PROPERTY_SUPPORTED_CHANNELS[prop][encQ.channel as Channel]) ||
-              !propNeedsToCheckChannel) {
+          if (!PROPERTY_SUPPORTED_CHANNELS[prop] ||  // all channels support this prop
+            PROPERTY_SUPPORTED_CHANNELS[prop][encQ.channel as Channel]) {
             fieldDef[prop] = encQ[prop];
           }
         }

--- a/src/model.ts
+++ b/src/model.ts
@@ -14,10 +14,10 @@ import {EnumSpecIndex} from './enumspecindex';
 import {SpecQuery, isAggregate, stack} from './query/spec';
 import {isDimension, isMeasure, EncodingQuery} from './query/encoding';
 import {GroupBy} from './query/groupby';
-import {spec as specShorthand, CHANNEL_SUPPORTS_PROPERTY} from './query/shorthand';
+import {spec as specShorthand, PROPERTY_SUPPORTED_CHANNELS} from './query/shorthand';
 import {RankingScore} from './ranking/ranking';
 import {Schema} from './schema';
-import {Dict, duplicate, extend} from './util';
+import {contains, Dict, duplicate, extend} from './util';
 
 export function getDefaultName(prop: Property) {
   switch (prop) {
@@ -695,11 +695,11 @@ export class SpecQueryModel {
         // otherwise, assign the proper to the field def
         if (encQ[prop] !== undefined) {
 
-          if (prop === Property.AXIS || prop === Property.LEGEND || prop === Property.SCALE || prop === Property.SORT) {
-            if (!isEnumSpec(encQ.channel) && CHANNEL_SUPPORTS_PROPERTY[encQ.channel as Channel][prop]) {
-              fieldDef[prop] = encQ[prop];
-            }
-          } else {
+          // We only output axis, legend, scale, or sort that have correct supporting channel
+          let propNeedsToCheckChannel: boolean = contains([Property.AXIS, Property.LEGEND, Property.SCALE, Property.SORT], prop);
+
+          if ((propNeedsToCheckChannel && !isEnumSpec(encQ.channel) && PROPERTY_SUPPORTED_CHANNELS[prop][encQ.channel as Channel]) ||
+              !propNeedsToCheckChannel) {
             fieldDef[prop] = encQ[prop];
           }
         }

--- a/src/model.ts
+++ b/src/model.ts
@@ -694,19 +694,19 @@ export class SpecQueryModel {
 
         // otherwise, assign the proper to the field def
         if (encQ[prop] !== undefined) {
-          if (prop === Property.AXIS && !isEnumSpec(encQ.channel)) {
+          if (prop === Property.AXIS) {
             if (CHANNEL_SUPPORTS_AXIS[encQ.channel as Channel]) {
               fieldDef[Property.AXIS] = encQ[Property.AXIS];
             }
-          } else if (prop === Property.LEGEND && !isEnumSpec(encQ.channel)) {
+          } else if (prop === Property.LEGEND) {
             if (CHANNEL_SUPPORTS_LEGEND[encQ.channel as Channel]) {
               fieldDef[Property.LEGEND] = encQ[Property.LEGEND];
             }
-          } else if (prop === Property.SCALE && !isEnumSpec(encQ.channel)) {
+          } else if (prop === Property.SCALE) {
             if (CHANNEL_SUPPORTS_SCALE[encQ.channel as Channel]) {
               fieldDef[Property.SCALE] = encQ[Property.SCALE];
             }
-          } else if (prop === Property.SORT && !isEnumSpec(encQ.channel)) {
+          } else if (prop === Property.SORT) {
             if (CHANNEL_SUPPORTS_SORT[encQ.channel as Channel]) {
               fieldDef[Property.SORT] = encQ[Property.SORT];
             }

--- a/src/model.ts
+++ b/src/model.ts
@@ -14,7 +14,7 @@ import {EnumSpecIndex} from './enumspecindex';
 import {SpecQuery, isAggregate, stack} from './query/spec';
 import {isDimension, isMeasure, EncodingQuery} from './query/encoding';
 import {GroupBy} from './query/groupby';
-import {spec as specShorthand, CHANNEL_SUPPORTS_AXIS, CHANNEL_SUPPORTS_LEGEND, CHANNEL_SUPPORTS_SCALE, CHANNEL_SUPPORTS_SORT} from './query/shorthand';
+import {spec as specShorthand, CHANNEL_SUPPORTS_PROPERTY} from './query/shorthand';
 import {RankingScore} from './ranking/ranking';
 import {Schema} from './schema';
 import {Dict, duplicate, extend} from './util';
@@ -694,21 +694,10 @@ export class SpecQueryModel {
 
         // otherwise, assign the proper to the field def
         if (encQ[prop] !== undefined) {
-          if (prop === Property.AXIS) {
-            if (CHANNEL_SUPPORTS_AXIS[encQ.channel as Channel]) {
-              fieldDef[Property.AXIS] = encQ[Property.AXIS];
-            }
-          } else if (prop === Property.LEGEND) {
-            if (CHANNEL_SUPPORTS_LEGEND[encQ.channel as Channel]) {
-              fieldDef[Property.LEGEND] = encQ[Property.LEGEND];
-            }
-          } else if (prop === Property.SCALE) {
-            if (CHANNEL_SUPPORTS_SCALE[encQ.channel as Channel]) {
-              fieldDef[Property.SCALE] = encQ[Property.SCALE];
-            }
-          } else if (prop === Property.SORT) {
-            if (CHANNEL_SUPPORTS_SORT[encQ.channel as Channel]) {
-              fieldDef[Property.SORT] = encQ[Property.SORT];
+
+          if (prop === Property.AXIS || prop === Property.LEGEND || prop === Property.SCALE || prop === Property.SORT) {
+            if (!isEnumSpec(encQ.channel) && CHANNEL_SUPPORTS_PROPERTY[encQ.channel as Channel][prop]) {
+              fieldDef[prop] = encQ[prop];
             }
           } else {
             fieldDef[prop] = encQ[prop];

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -51,7 +51,7 @@ export function vlSpec(vlspec: ExtendedUnitSpec,
 }
 
 export const CHANNEL_SUPPORTS_AXIS: Dict<boolean> =
-  [Channel.X, Channel.Y]
+  [Channel.X, Channel.Y, Channel.ROW, Channel.COLUMN]
     .reduce((m, channel) => {
       m[channel] = true;
       return m;
@@ -65,7 +65,7 @@ export const CHANNEL_SUPPORTS_LEGEND: Dict<boolean> =
     }, {} as Dict<boolean>);
 
 export const CHANNEL_SUPPORTS_SCALE: Dict<boolean> =
-  [Channel.X, Channel.Y, Channel.COLOR, Channel.OPACITY, Channel.OPACITY, Channel.SIZE, Channel.SHAPE]
+  [Channel.X, Channel.Y, Channel.COLOR, Channel.OPACITY, Channel.OPACITY, Channel.ROW, Channel.COLUMN, Channel.SIZE, Channel.SHAPE]
     .reduce((m, channel) => {
       m[channel] = true;
       return m;

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -234,7 +234,7 @@ export function fieldDef(encQ: EncodingQuery,
 
   // Scale
   // TODO: legend
-  for (const nestedPropParent of [Property.AXIS, Property.LEGEND, Property.SCALE, Property.SORT]) {
+  for (const nestedPropParent of [Property.SCALE, Property.SORT, Property.AXIS, Property.LEGEND]) {
     if ((nestedPropParent === Property.AXIS) && !isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_AXIS[encQ.channel as Channel]) {
       continue;
     }

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -50,33 +50,58 @@ export function vlSpec(vlspec: ExtendedUnitSpec,
   return spec(specQ);
 }
 
-export const CHANNEL_SUPPORTS_AXIS: Dict<boolean> =
+const CHANNEL_SUPPORTS_AXIS: Dict<boolean> =
   [Channel.X, Channel.Y, Channel.ROW, Channel.COLUMN]
     .reduce((m, channel) => {
       m[channel] = true;
       return m;
     }, {} as Dict<boolean>);
 
-export const CHANNEL_SUPPORTS_LEGEND: Dict<boolean> =
+const CHANNEL_SUPPORTS_LEGEND: Dict<boolean> =
   [Channel.COLOR, Channel.OPACITY, Channel.SIZE, Channel.SHAPE]
     .reduce((m, channel) => {
       m[channel] = true;
       return m;
     }, {} as Dict<boolean>);
 
-export const CHANNEL_SUPPORTS_SCALE: Dict<boolean> =
+const CHANNEL_SUPPORTS_SCALE: Dict<boolean> =
   [Channel.X, Channel.Y, Channel.COLOR, Channel.OPACITY, Channel.OPACITY, Channel.ROW, Channel.COLUMN, Channel.SIZE, Channel.SHAPE]
     .reduce((m, channel) => {
       m[channel] = true;
       return m;
     }, {} as Dict<boolean>);
 
-export const CHANNEL_SUPPORTS_SORT: Dict<boolean> =
+const CHANNEL_SUPPORTS_SORT: Dict<boolean> =
   [Channel.X, Channel.Y, Channel.PATH, Channel.ORDER]
     .reduce((m, channel) => {
       m[channel] = true;
       return m;
     }, {} as Dict<boolean>);
+
+export const CHANNEL_SUPPORTS_PROPERTY =
+  [Channel.COLOR, Channel.COLUMN, Channel.DETAIL, Channel.LABEL, Channel.OPACITY, Channel.ORDER, Channel.PATH,
+   Channel.ROW, Channel.SHAPE, Channel.SIZE, Channel.TEXT, Channel.X, Channel.X2, Channel.Y, Channel.Y2]
+    .reduce((m, channel) => {
+      let n: Dict<boolean> = {};
+      if (CHANNEL_SUPPORTS_AXIS[channel]) {
+        n[Property.AXIS] = true;
+        m[channel] = n;
+      }
+      if (CHANNEL_SUPPORTS_LEGEND[channel]) {
+        n[Property.LEGEND] = true;
+        m[channel] = n;
+      }
+      if (CHANNEL_SUPPORTS_SORT[channel]) {
+        n[Property.SORT] = true;
+        m[channel] = n;
+      }
+      if (CHANNEL_SUPPORTS_SCALE[channel]) {
+        n[Property.SCALE] = true;
+        m[channel] = n;
+      }
+
+      return m;
+    }, {} as Dict<Dict<boolean>>);
 
 /**
  * Returns a shorthand for a spec query
@@ -233,16 +258,7 @@ export function fieldDef(encQ: EncodingQuery,
   }
 
   for (const nestedPropParent of [Property.SCALE, Property.SORT, Property.AXIS, Property.LEGEND]) {
-    if ((nestedPropParent === Property.AXIS) && !isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_AXIS[encQ.channel as Channel]) {
-      continue;
-    }
-    if ((nestedPropParent === Property.LEGEND) && !isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_LEGEND[encQ.channel as Channel]) {
-      continue;
-    }
-    if ((nestedPropParent === Property.SCALE) && !isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_SCALE[encQ.channel as Channel]) {
-      continue;
-    }
-    if ((nestedPropParent === Property.SORT) && !isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_SORT[encQ.channel as Channel]) {
+    if (!isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_PROPERTY[encQ.channel as Channel][nestedPropParent]) {
       continue;
     }
 

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -50,58 +50,12 @@ export function vlSpec(vlspec: ExtendedUnitSpec,
   return spec(specQ);
 }
 
-const CHANNEL_SUPPORTS_AXIS: Dict<boolean> =
-  [Channel.X, Channel.Y, Channel.ROW, Channel.COLUMN]
-    .reduce((m, channel) => {
-      m[channel] = true;
-      return m;
-    }, {} as Dict<boolean>);
-
-const CHANNEL_SUPPORTS_LEGEND: Dict<boolean> =
-  [Channel.COLOR, Channel.OPACITY, Channel.SIZE, Channel.SHAPE]
-    .reduce((m, channel) => {
-      m[channel] = true;
-      return m;
-    }, {} as Dict<boolean>);
-
-const CHANNEL_SUPPORTS_SCALE: Dict<boolean> =
-  [Channel.X, Channel.Y, Channel.COLOR, Channel.OPACITY, Channel.OPACITY, Channel.ROW, Channel.COLUMN, Channel.SIZE, Channel.SHAPE]
-    .reduce((m, channel) => {
-      m[channel] = true;
-      return m;
-    }, {} as Dict<boolean>);
-
-const CHANNEL_SUPPORTS_SORT: Dict<boolean> =
-  [Channel.X, Channel.Y, Channel.PATH, Channel.ORDER]
-    .reduce((m, channel) => {
-      m[channel] = true;
-      return m;
-    }, {} as Dict<boolean>);
-
-export const CHANNEL_SUPPORTS_PROPERTY =
-  [Channel.COLOR, Channel.COLUMN, Channel.DETAIL, Channel.LABEL, Channel.OPACITY, Channel.ORDER, Channel.PATH,
-   Channel.ROW, Channel.SHAPE, Channel.SIZE, Channel.TEXT, Channel.X, Channel.X2, Channel.Y, Channel.Y2]
-    .reduce((m, channel) => {
-      let n: Dict<boolean> = {};
-      if (CHANNEL_SUPPORTS_AXIS[channel]) {
-        n[Property.AXIS] = true;
-        m[channel] = n;
-      }
-      if (CHANNEL_SUPPORTS_LEGEND[channel]) {
-        n[Property.LEGEND] = true;
-        m[channel] = n;
-      }
-      if (CHANNEL_SUPPORTS_SORT[channel]) {
-        n[Property.SORT] = true;
-        m[channel] = n;
-      }
-      if (CHANNEL_SUPPORTS_SCALE[channel]) {
-        n[Property.SCALE] = true;
-        m[channel] = n;
-      }
-
-      return m;
-    }, {} as Dict<Dict<boolean>>);
+export const PROPERTY_SUPPORTED_CHANNELS = {
+  axis: {x: true, y: true, row: true, column: true},
+  legend: {color: true, opacity: true, size: true, shape: true},
+  scale: {x: true, y: true, color: true, opacity: true, row: true, column: true, size: true, shape: true},
+  sort: {x: true, y: true, path: true, order: true}
+};
 
 /**
  * Returns a shorthand for a spec query
@@ -258,7 +212,7 @@ export function fieldDef(encQ: EncodingQuery,
   }
 
   for (const nestedPropParent of [Property.SCALE, Property.SORT, Property.AXIS, Property.LEGEND]) {
-    if (!isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_PROPERTY[encQ.channel as Channel][nestedPropParent]) {
+    if (!isEnumSpec(encQ.channel) && !PROPERTY_SUPPORTED_CHANNELS[nestedPropParent][encQ.channel as Channel]) {
       continue;
     }
 

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -232,8 +232,6 @@ export function fieldDef(encQ: EncodingQuery,
     }
   }
 
-  // Scale
-  // TODO: legend
   for (const nestedPropParent of [Property.SCALE, Property.SORT, Property.AXIS, Property.LEGEND]) {
     if ((nestedPropParent === Property.AXIS) && !isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_AXIS[encQ.channel as Channel]) {
       continue;

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -1,3 +1,4 @@
+import {Channel} from 'vega-lite/src/channel';
 import {expression} from 'vega-lite/src/filter';
 import {Filter} from 'vega-lite/src/filter';
 import {Formula} from 'vega-lite/src/transform';
@@ -48,6 +49,34 @@ export function vlSpec(vlspec: ExtendedUnitSpec,
   const specQ = fromSpec(vlspec);
   return spec(specQ);
 }
+
+export const CHANNEL_SUPPORTS_AXIS: Dict<boolean> =
+  [Channel.X, Channel.Y]
+    .reduce((m, channel) => {
+      m[channel] = true;
+      return m;
+    }, {} as Dict<boolean>);
+
+export const CHANNEL_SUPPORTS_LEGEND: Dict<boolean> =
+  [Channel.COLOR, Channel.OPACITY, Channel.SIZE, Channel.SHAPE]
+    .reduce((m, channel) => {
+      m[channel] = true;
+      return m;
+    }, {} as Dict<boolean>);
+
+export const CHANNEL_SUPPORTS_SCALE: Dict<boolean> =
+  [Channel.X, Channel.Y, Channel.COLOR, Channel.OPACITY, Channel.OPACITY, Channel.SIZE, Channel.SHAPE]
+    .reduce((m, channel) => {
+      m[channel] = true;
+      return m;
+    }, {} as Dict<boolean>);
+
+export const CHANNEL_SUPPORTS_SORT: Dict<boolean> =
+  [Channel.X, Channel.Y, Channel.PATH, Channel.ORDER]
+    .reduce((m, channel) => {
+      m[channel] = true;
+      return m;
+    }, {} as Dict<boolean>);
 
 /**
  * Returns a shorthand for a spec query
@@ -204,9 +233,21 @@ export function fieldDef(encQ: EncodingQuery,
   }
 
   // Scale
-  // TODO(#226):
-  // write toSpec() and toShorthand() in a way that prevents outputting inapplicable scale, sort, axis / legend
-  for (const nestedPropParent of [Property.SCALE, Property.SORT, Property.AXIS, Property.LEGEND]) {
+  // TODO: legend
+  for (const nestedPropParent of [Property.AXIS, Property.LEGEND, Property.SCALE, Property.SORT]) {
+    if ((nestedPropParent === Property.AXIS) && !isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_AXIS[encQ.channel as Channel]) {
+      continue;
+    }
+    if ((nestedPropParent === Property.LEGEND) && !isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_LEGEND[encQ.channel as Channel]) {
+      continue;
+    }
+    if ((nestedPropParent === Property.SCALE) && !isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_SCALE[encQ.channel as Channel]) {
+      continue;
+    }
+    if ((nestedPropParent === Property.SORT) && !isEnumSpec(encQ.channel) && !CHANNEL_SUPPORTS_SORT[encQ.channel as Channel]) {
+      continue;
+    }
+
     if (include[nestedPropParent]) {
       if (encQ[nestedPropParent] && !isEnumSpec(encQ[nestedPropParent])) {
         // `sort` can be a string (ascending/descending).

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -293,6 +293,62 @@ describe('SpecQueryModel', () => {
       });
     });
 
+    it('should return a Vega-Lite spec that does not output inapplicable legend', () => {
+      const specM = buildSpecQueryModel({
+        data: {values: [{A: 1}]},
+        transform: {filter: 'datum.A===1'},
+        mark: Mark.BAR,
+        encodings: [
+          {
+            channel: Channel.X,
+            field: 'A',
+            type: Type.QUANTITATIVE,
+            axis: {orient: AxisOrient.TOP, shortTimeLabels: true, ticks: 5, title: 'test x channel'},
+            legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'},
+          }
+        ]
+      });
+
+      const spec = specM.toSpec();
+      assert.deepEqual(spec, {
+        data: {values: [{A: 1}]},
+        transform: {filter: 'datum.A===1'},
+        mark: Mark.BAR,
+        encoding: {
+          x: {field: 'A', type: Type.QUANTITATIVE, axis: {orient: AxisOrient.TOP, shortTimeLabels: true, ticks: 5, title: 'test x channel'}},
+        },
+        config: DEFAULT_SPEC_CONFIG
+      });
+    });
+
+    it('should return a Vega-Lite spec that does not output inapplicable axis', () => {
+      const specM = buildSpecQueryModel({
+        data: {values: [{A: 1}]},
+        transform: {filter: 'datum.A===1'},
+        mark: Mark.BAR,
+        encodings: [
+          {
+            channel: Channel.COLOR,
+            field: 'B',
+            type: Type.QUANTITATIVE,
+            axis: {orient: AxisOrient.TOP, shortTimeLabels: true, ticks: 5, title: 'test x channel'},
+            legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'},
+          }
+        ]
+      });
+
+      const spec = specM.toSpec();
+      assert.deepEqual(spec, {
+        data: {values: [{A: 1}]},
+        transform: {filter: 'datum.A===1'},
+        mark: Mark.BAR,
+        encoding: {
+          color: {field: 'B', type: Type.QUANTITATIVE, legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'}}
+        },
+        config: DEFAULT_SPEC_CONFIG
+      });
+    });
+
     it('should return a spec with no bin if the bin=false.', () => {
       const specM = buildSpecQueryModel({
         data: {values: [{A: 1}]},

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -339,6 +339,38 @@ describe('query/shorthand', () => {
       assert.equal(str, 'point|color:a,n,legend={"orient":"right","labelAlign":"left","symbolSize":12,"title":"test title"}');
     });
 
+    it('should return a fieldDefShorthand string without incorrect legend', () => {
+      const str = specShorthand({
+        mark: Mark.POINT,
+        encodings: [
+          {
+            axis: {orient: AxisOrient.RIGHT},
+            channel: Channel.X,
+            field: 'a',
+            type: Type.NOMINAL,
+            legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'}
+          }
+        ]
+      });
+      assert.equal(str, 'point|x:a,n,axis={"orient":"right"}');
+    });
+
+    it('should return a fieldDefShorthand string without incorrect axis', () => {
+      const str = specShorthand({
+        mark: Mark.POINT,
+        encodings: [
+          {
+            axis: {orient: AxisOrient.RIGHT},
+            channel: Channel.COLOR,
+            field: 'a',
+            type: Type.NOMINAL,
+            legend: {labelAlign: 'left'}
+          }
+        ]
+      });
+      assert.equal(str, 'point|color:a,n,legend={"labelAlign":"left"}');
+    });
+
     it('should return correct fieldDefShorthand string for scale with a string[] domain', () => {
       const str = fieldDefShorthand({
         channel: Channel.X, field: 'a', type: Type.NOMINAL, scale: {domain: ['cats', 'dogs']}


### PR DESCRIPTION
Fix #226
In this PR:
- Create dictionaries of channels that support `scale`, `sort`,`axis`, `legend` properties
- Prevent toSpec and Shorthand from outputting properties that are used with inapplicable channel.