### PR TITLE
Ordinal or nominal type is not inferred if distinct is above a limit …

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,9 @@ export interface QueryConfig {
   /** Default ratio for number fields to be considered ordinal */
   numberOrdinalProportion?: number;
 
+  /** Default cutoff for not applying the numberOrdinalProportion inference */
+  numberOrdinalLimit?: number;
+
   /** Default maxbins to enumerate */
   maxBinsList?: number[];
 
@@ -295,6 +298,7 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
   scaleTypes: [undefined, ScaleType.LOG],
 
   numberOrdinalProportion: .05,
+  numberOrdinalLimit: 50,
 
   // CONSTRAINTS
   // Spec Constraints -- See description inside src/constraints/spec.ts

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -36,8 +36,8 @@ export class Schema {
       if (primitiveType === PrimitiveType.NUMBER) {
         type = Type.QUANTITATIVE;
       } else if (primitiveType === PrimitiveType.INTEGER) {
-        // use ordinal or nominal when cardinality of integer type is relatively low
-        if (distinct / summary.count < opt.numberOrdinalProportion) {
+        // use ordinal or nominal when cardinality of integer type is relatively low and the distinct values are less than an amount specified in options
+        if ((distinct < opt.numberOrdinalLimit) && (distinct / summary.count < opt.numberOrdinalProportion)) {
           // use nominal if the integers are 1,2,3,...,N or 0,1,2,3,...,N-1 where N = cardinality
           type = ((summary.max as number) - (summary.min as number) === distinct - 1 && contains([0,1], summary.min)) ? Type.NOMINAL : Type.ORDINAL;
         } else {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -65,6 +65,21 @@ describe('schema', () => {
       assert.equal(schema.type('d'), Type.TEMPORAL);
     });
 
+    it('should infer quantitative type for integers when cardinality is much less than the total but distinct is high', () => {
+      const numberData = [];
+      // add enough non-distinct data to make the field nominal
+      var total = 1 / DEFAULT_QUERY_CONFIG.numberOrdinalProportion + 1;
+      for (let i = 0; i < total * DEFAULT_QUERY_CONFIG.numberOrdinalLimit; i++) {
+        numberData.push({a: 1});
+      }
+      // add enough distinct data to go over numberOrdinalLimit
+      for (let i = 0; i < DEFAULT_QUERY_CONFIG.numberOrdinalLimit + 1; i++) {
+        numberData.push({a: i});
+      }
+      const numberSchema = Schema.build(numberData);
+      assert.equal(numberSchema.type('a'), Type.QUANTITATIVE);
+    });
+
     it('should infer nominal type for integers when cardinality is much less than the total', () => {
       const numberData = [];
       // add enough non-distinct data to make the field nominal


### PR DESCRIPTION
Previously, ordinal or nominal type would be inferred if distinct was proportionately low compared to overall count. This wasn't appropriate for some datasets. Now, this won't occur if there are more than 50 distinct values.

Fixes https://github.com/uwdata/voyager2/issues/88