### PR TITLE
Relax hasAllRequiredChannelsForMark constraint for when mark is an enum spec

### DIFF
--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -225,7 +225,7 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
           return specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
         case Mark.POINT:
           // This allows generating a point plot if channel was not an enum spec.
-          return !specM.enumSpecIndex.hasProperty(Property.CHANNEL) || 
+          return !specM.enumSpecIndex.hasProperty(Property.CHANNEL) ||
                  specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
       }
       /* istanbul ignore next */

--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -224,7 +224,8 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
         case Mark.RULE:
           return specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
         case Mark.POINT:
-          return !specM.enumSpecIndex.hasProperty(Property.CHANNEL) || // This allows a point plot to generate if channel was enumspec
+          // This allows generating a point plot if channel was not an enum spec.
+          return !specM.enumSpecIndex.hasProperty(Property.CHANNEL) || 
                  specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
       }
       /* istanbul ignore next */

--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -224,7 +224,7 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
         case Mark.RULE:
           return specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
         case Mark.POINT:
-          return !!specM.enumSpecIndex.mark || // This allows a point plot to generate if x or y aren't used but mark was ?
+          return !specM.enumSpecIndex.hasProperty(Property.CHANNEL) || // This allows a point plot to generate if channel was enumspec
                  specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
       }
       /* istanbul ignore next */
@@ -380,10 +380,6 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
     allowEnumSpecForProperties: false,
     strict: false,
     satisfy: (specM: SpecQueryModel, schema: Schema, opt: QueryConfig) => {
-      if (specM.enumSpecIndex.hasProperty(Property.CHANNEL) &&
-        !(specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y))) {
-        return true;
-      }
 
       return some(NONSPATIAL_CHANNELS, (channel) => specM.channelUsed(channel)) ?
         // if non-positional channels are used, then both x and y must be used.

--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -219,11 +219,13 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
           return specM.channelUsed(Channel.TEXT);
         case Mark.BAR:
         case Mark.CIRCLE:
-        case Mark.POINT:
         case Mark.SQUARE:
         case Mark.TICK:
         case Mark.RULE:
           return specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
+        case Mark.POINT:
+          return isEnumSpec(specM.enumSpecIndex.mark) ? true :
+            specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
       }
       /* istanbul ignore next */
       throw new Error('hasAllRequiredChannelsForMark not implemented for mark' + mark);

--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -224,7 +224,7 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
         case Mark.RULE:
           return specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
         case Mark.POINT:
-          return !!specM.enumSpecIndex.mark ||
+          return !!specM.enumSpecIndex.mark || // This allows a point plot to generate if x or y aren't used but mark was ?
                  specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
       }
       /* istanbul ignore next */

--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -224,8 +224,8 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
         case Mark.RULE:
           return specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
         case Mark.POINT:
-          return isEnumSpec(specM.enumSpecIndex.mark) ? true :
-            specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
+          return !!specM.enumSpecIndex.mark ||
+                 specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y);
       }
       /* istanbul ignore next */
       throw new Error('hasAllRequiredChannelsForMark not implemented for mark' + mark);
@@ -380,6 +380,11 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
     allowEnumSpecForProperties: false,
     strict: false,
     satisfy: (specM: SpecQueryModel, schema: Schema, opt: QueryConfig) => {
+      if (specM.enumSpecIndex.hasProperty(Property.CHANNEL) &&
+        !(specM.channelUsed(Channel.X) || specM.channelUsed(Channel.Y))) {
+        return true;
+      }
+
       return some(NONSPATIAL_CHANNELS, (channel) => specM.channelUsed(channel)) ?
         // if non-positional channels are used, then both x and y must be used.
         specM.channelUsed(Channel.X) && specM.channelUsed(Channel.Y) :

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -284,7 +284,7 @@ describe('constraints/spec', () => {
 
     it('should return false for bar/circle/point/square/tick/rule with neither x nor y', () => {
       [Channel.COLOR, Channel.SHAPE].forEach((channel) => {
-        [Mark.BAR, Mark.CIRCLE, Mark.POINT, Mark.SQUARE, Mark.TEXT, Mark.RULE].forEach((mark) => {
+        [Mark.BAR, Mark.CIRCLE, Mark.SQUARE, Mark.TEXT, Mark.RULE].forEach((mark) => {
           const specM = buildSpecQueryModel({
             mark: mark,
             encodings: [
@@ -293,6 +293,18 @@ describe('constraints/spec', () => {
           });
           assert.isFalse(SPEC_CONSTRAINT_INDEX['hasAllRequiredChannelsForMark'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
         });
+      });
+    });
+
+    it('should return true for point with neither x nor y', () => {
+      [Channel.COLOR, Channel.SHAPE].forEach((channel) => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {channel: channel, field: 'N', type: Type.NOMINAL}
+          ]
+        });
+        assert.isTrue(SPEC_CONSTRAINT_INDEX['hasAllRequiredChannelsForMark'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
       });
     });
 

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -46,7 +46,7 @@ describe('generate', function () {
           }]
         };
         const answerSet = generate(query, schema);
-        assert.equal(answerSet.length, 4);
+        assert.equal(answerSet.length, 6);
 
         assert.equal(answerSet[0].getMark(), Mark.POINT);
         assert.equal(answerSet[0].getEncodingQueryByIndex(0).channel, Channel.X);
@@ -56,6 +56,10 @@ describe('generate', function () {
         assert.equal(answerSet[2].getEncodingQueryByIndex(0).channel, Channel.Y);
         assert.equal(answerSet[3].getMark(), Mark.TICK);
         assert.equal(answerSet[3].getEncodingQueryByIndex(0).channel, Channel.Y);
+        assert.equal(answerSet[4].getEncodingQueryByIndex(0).channel, Channel.SIZE);
+        assert.equal(answerSet[4].getMark(), Mark.POINT);
+        assert.equal(answerSet[5].getEncodingQueryByIndex(0).channel, Channel.COLOR);
+        assert.equal(answerSet[5].getMark(), Mark.POINT);
       });
     });
 

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -36,22 +36,7 @@ describe('generate', function () {
     });
 
     describe('Q with mark=point, channel=?', () => {
-      it('should only enumerate channel x and channel y with omitNonPositionalOverPositionalChannels turned off', () => {
-        const query = {
-          mark: Mark.POINT,
-          encodings: [{
-            channel: '?',
-            field: 'A',
-            type: Type.QUANTITATIVE
-          }]
-        };
-        const answerSet = generate(query, schema, extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOverPositionalChannels: false}));
-        assert.equal(answerSet.length, 2);
-        assert.equal(answerSet[0].getEncodingQueryByIndex(0).channel, Channel.X);
-        assert.equal(answerSet[1].getEncodingQueryByIndex(0).channel, Channel.Y);
-      });
-
-      it('should only enumerate channel x and y with omitNonPositionalOverPositionalChannels turned on', () => {
+      it('should only enumerate channel x and y', () => {
         const query = {
           mark: Mark.POINT,
           encodings: [{
@@ -61,6 +46,21 @@ describe('generate', function () {
           }]
         };
         const answerSet = generate(query, schema);
+        assert.equal(answerSet.length, 2);
+        assert.equal(answerSet[0].getEncodingQueryByIndex(0).channel, Channel.X);
+        assert.equal(answerSet[1].getEncodingQueryByIndex(0).channel, Channel.Y);
+      });
+
+      it('should only enumerate channel x and channel y even if omitNonPositionalOverPositionalChannels turned off', () => {
+        const query = {
+          mark: Mark.POINT,
+          encodings: [{
+            channel: '?',
+            field: 'A',
+            type: Type.QUANTITATIVE
+          }]
+        };
+        const answerSet = generate(query, schema, extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOverPositionalChannels: false}));
         assert.equal(answerSet.length, 2);
         assert.equal(answerSet[0].getEncodingQueryByIndex(0).channel, Channel.X);
         assert.equal(answerSet[1].getEncodingQueryByIndex(0).channel, Channel.Y);

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -68,7 +68,7 @@ describe('generate', function () {
     });
 
     describe('Q with mark=?, channel=column, bin', () => {
-      it.only('should generate point marks', () => {
+      it('should generate point marks', () => {
         const query = {
           mark: '?',
           encodings: [{

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -35,6 +35,55 @@ describe('generate', function () {
       });
     });
 
+    describe('Q with mark=point, channel=?', () => {
+      it('should only enumerate channel x and channel y with omitNonPositionalOverPositionalChannels turned off', () => {
+        const query = {
+          mark: Mark.POINT,
+          encodings: [{
+            channel: '?',
+            field: 'A',
+            type: Type.QUANTITATIVE
+          }]
+        };
+        const answerSet = generate(query, schema, extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOverPositionalChannels: false}));
+        assert.equal(answerSet.length, 2);
+        assert.equal(answerSet[0].getEncodingQueryByIndex(0).channel, Channel.X);
+        assert.equal(answerSet[1].getEncodingQueryByIndex(0).channel, Channel.Y);
+      });
+
+      it('should only enumerate channel x and y with omitNonPositionalOverPositionalChannels turned on', () => {
+        const query = {
+          mark: Mark.POINT,
+          encodings: [{
+            channel: '?',
+            field: 'A',
+            type: Type.QUANTITATIVE
+          }]
+        };
+        const answerSet = generate(query, schema);
+        assert.equal(answerSet.length, 2);
+        assert.equal(answerSet[0].getEncodingQueryByIndex(0).channel, Channel.X);
+        assert.equal(answerSet[1].getEncodingQueryByIndex(0).channel, Channel.Y);
+      });
+    });
+
+    describe('Q with mark=?, channel=column, bin', () => {
+      it.only('should generate point marks', () => {
+        const query = {
+          mark: '?',
+          encodings: [{
+            channel: Channel.COLUMN,
+            field: 'A',
+            type: Type.QUANTITATIVE,
+            bin: {}
+          }]
+        };
+        const answerSet = generate(query, schema);
+        assert.equal(answerSet.length, 1);
+        assert.equal(answerSet[0].getMark(), Mark.POINT);
+      });
+    });
+
     describe('Q with mark=?, channel=?', () => {
       it('should enumerate tick or point mark with x or y channel', () => {
         const query = {
@@ -45,8 +94,9 @@ describe('generate', function () {
             type: Type.QUANTITATIVE
           }]
         };
-        const answerSet = generate(query, schema);
-        assert.equal(answerSet.length, 6);
+
+        const answerSet = generate(query, schema, extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOverPositionalChannels: false}));
+        assert.equal(answerSet.length, 4);
 
         assert.equal(answerSet[0].getMark(), Mark.POINT);
         assert.equal(answerSet[0].getEncodingQueryByIndex(0).channel, Channel.X);
@@ -56,10 +106,6 @@ describe('generate', function () {
         assert.equal(answerSet[2].getEncodingQueryByIndex(0).channel, Channel.Y);
         assert.equal(answerSet[3].getMark(), Mark.TICK);
         assert.equal(answerSet[3].getEncodingQueryByIndex(0).channel, Channel.Y);
-        assert.equal(answerSet[4].getEncodingQueryByIndex(0).channel, Channel.SIZE);
-        assert.equal(answerSet[4].getMark(), Mark.POINT);
-        assert.equal(answerSet[5].getEncodingQueryByIndex(0).channel, Channel.COLOR);
-        assert.equal(answerSet[5].getMark(), Mark.POINT);
       });
     });
 

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -19,6 +19,46 @@ const CONFIG_WITH_AUTO_ADD_COUNT = extend({}, DEFAULT_QUERY_CONFIG, {autoAddCoun
 
 describe('generate', function () {
   describe('1D', () => {
+    describe('Q with mark=?, channel=size', () => {
+      it('should enumerate mark=point and generate a point plot', () => {
+        const query = {
+          mark: '?',
+          encodings: [{
+            channel: Channel.SIZE,
+            field: 'A',
+            type: Type.QUANTITATIVE
+          }]
+        };
+        const answerSet = generate(query, schema);
+        assert.equal(answerSet.length, 1);
+        assert.equal(answerSet[0].getMark(), Mark.POINT);
+      });
+    });
+
+    describe('Q with mark=?, channel=?', () => {
+      it('should enumerate tick or point mark with x or y channel', () => {
+        const query = {
+          mark: '?',
+          encodings: [{
+            channel: '?',
+            field: 'A',
+            type: Type.QUANTITATIVE
+          }]
+        };
+        const answerSet = generate(query, schema);
+        assert.equal(answerSet.length, 4);
+
+        assert.equal(answerSet[0].getMark(), Mark.POINT);
+        assert.equal(answerSet[0].getEncodingQueryByIndex(0).channel, Channel.X);
+        assert.equal(answerSet[1].getMark(), Mark.TICK);
+        assert.equal(answerSet[1].getEncodingQueryByIndex(0).channel, Channel.X);
+        assert.equal(answerSet[2].getMark(), Mark.POINT);
+        assert.equal(answerSet[2].getEncodingQueryByIndex(0).channel, Channel.Y);
+        assert.equal(answerSet[3].getMark(), Mark.TICK);
+        assert.equal(answerSet[3].getEncodingQueryByIndex(0).channel, Channel.Y);
+      });
+    });
+
     describe('Q with aggregate=?, bin=?', () => {
       it('should enumerate raw, bin, aggregate', () => {
         const query = {


### PR DESCRIPTION
fix #237 
- Allow a point plot to generate when mark is an enum spec.

fix #235 
- Relax spec when there is only row or column channel.