### PR TITLE
Add timeUnitHasVariation method for schema

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -200,7 +200,7 @@ export interface QueryConfig {
   maxCardinalityForCategoricalColor?: number;
   maxCardinalityForFacet?: number;
   maxCardinalityForShape?: number;
-  timeUnitShouldShowVariation?: boolean;
+  timeUnitShouldHaveVariation?: boolean;
   typeMatchesSchemaType?: boolean;
 
   // STYLIZE
@@ -330,7 +330,7 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
   maxCardinalityForCategoricalColor: 20,
   maxCardinalityForFacet: 10,
   maxCardinalityForShape: 6,
-  timeUnitShouldShowVariation: true,
+  timeUnitShouldHaveVariation: true,
   typeMatchesSchemaType: true,
 
   // STYLIZE

--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -162,7 +162,7 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
     strict: false,
     satisfy: (encQ: EncodingQuery, schema: Schema, opt: QueryConfig) => {
       if (encQ.timeUnit && encQ.type === Type.TEMPORAL) {
-        return schema.cardinality(encQ, false, true) > 1;
+        return schema.timeUnitHasVariation(encQ);
       }
       return true;
     }

--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -155,7 +155,7 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
       return true;
     }
   },{
-    name: 'timeUnitShouldShowVariation',
+    name: 'timeUnitShouldHaveVariation',
     description: 'A particular time unit should be applied only if they produce unique values.',
     properties: [Property.TIMEUNIT, Property.TYPE],
     allowEnumSpecForProperties: false,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -199,13 +199,18 @@ export class Schema {
   }
 
   /**
-   * Given an EncodingQuery with a timeUnit, returns true if the number of
-   * dates that are completely distinct in all parts of the timeUnit is greater than 1.
+   * Given an EncodingQuery with a timeUnit, returns true if the date field
+   * has multiple distinct values for all parts of the timeUnit. Returns undefined
+   * if the timeUnit is undefined.
    * i.e.
    * ('yearmonth', [Jan 1 2000, Feb 2 2000] returns false)
    * ('yearmonth', [Jan 1 2000, Feb 2 2001] returns true)
    */
   public timeUnitHasVariation(encQ: EncodingQuery): boolean {
+    if (!encQ.timeUnit) {
+      return;
+    }
+
     // if there is no variation in `date`, there should not be variation in `day`
     if (encQ.timeUnit === TimeUnit.DAY) {
       const dateEncQ: EncodingQuery = extend({}, encQ, {timeUnit: TimeUnit.DATE});

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,7 +1,7 @@
 import {Type} from 'vega-lite/src/type';
 import {Channel} from 'vega-lite/src/channel';
 import {autoMaxBins} from 'vega-lite/src/bin';
-import {TimeUnit, convert} from 'vega-lite/src/timeunit';
+import {TimeUnit, containsTimeUnit, convert, SINGLE_TIMEUNITS} from 'vega-lite/src/timeunit';
 import {summary} from 'datalib/src/stats';
 import {inferAll} from 'datalib/src/import/type';
 import * as dlBin from 'datalib/src/bins/bins';
@@ -196,6 +196,35 @@ export class Schema {
         return null;
       }
     }
+  }
+
+  /**
+   * Given an EncodingQuery with a timeUnit, returns true if the number of
+   * dates that are completely distinct in all parts of the timeUnit is greater than 1.
+   * i.e.
+   * ('yearmonth', [Jan 1 2000, Feb 2 2000] returns false)
+   * ('yearmonth', [Jan 1 2000, Feb 2 2001] returns true)
+   */
+  public timeUnitHasVariation(encQ: EncodingQuery): boolean {
+    // if there is no variation in `date`, there should not be variation in `day`
+    if (encQ.timeUnit === TimeUnit.DAY) {
+      const dateEncQ: EncodingQuery = extend({}, encQ);
+      dateEncQ.timeUnit = TimeUnit.DATE;
+      if (this.cardinality(dateEncQ, false, true) <= 1) {
+        return false;
+      }
+    }
+
+    let fullTimeUnit = encQ.timeUnit;
+    for (let singleUnit of SINGLE_TIMEUNITS) {
+      if (containsTimeUnit(fullTimeUnit as TimeUnit, singleUnit)) {
+        encQ.timeUnit = singleUnit;
+        if (this.cardinality(encQ, false, true) <= 1) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   public domain(encQ: EncodingQuery): any[] {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -208,8 +208,7 @@ export class Schema {
   public timeUnitHasVariation(encQ: EncodingQuery): boolean {
     // if there is no variation in `date`, there should not be variation in `day`
     if (encQ.timeUnit === TimeUnit.DAY) {
-      const dateEncQ: EncodingQuery = extend({}, encQ);
-      dateEncQ.timeUnit = TimeUnit.DATE;
+      const dateEncQ: EncodingQuery = extend({}, encQ, {timeUnit: TimeUnit.DATE});
       if (this.cardinality(dateEncQ, false, true) <= 1) {
         return false;
       }

--- a/test/fixture.ts
+++ b/test/fixture.ts
@@ -21,7 +21,10 @@ const fixtures: FieldSchema[] = [{
   field: 'T',
   type: Type.TEMPORAL,
   primitiveType: PrimitiveType.DATE,
-  stats: {distinct: 100} as any, // HACK so that we don't have to define all summary properties
+  stats: {
+    distinct: 100,
+    unique: {'2000/1/1': 1, '2000/1/2': 1}
+  } as any, // HACK so that we don't have to define all summary properties
   timeStats: {
     year: {
       distinct: 2,

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -469,6 +469,15 @@ describe('schema', () => {
         timeUnit: 'day'
       }));
     });
+
+    it('should return undefined when timeUnit is undefined', () => {
+      const variationData = [];
+      const variationSchema = Schema.build(variationData);
+      assert.isUndefined(variationSchema.timeUnitHasVariation({
+        field: 'a',
+        channel: Channel.X
+      }));
+    });
   });
 
   describe('stats', () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -430,6 +430,47 @@ describe('schema', () => {
     });
   });
 
+  describe('timeUnitHasVariation', () => {
+    it('should return true when all parts of a specified multi-timeUnit have at least 2 distinct values', () => {
+      const variationData = [
+        {a: 'Jan 1, 2000'},
+        {a: 'Feb 1, 2001'}
+      ];
+      const variationSchema = Schema.build(variationData);
+      assert.isTrue(variationSchema.timeUnitHasVariation({
+        field: 'a',
+        channel: Channel.X,
+        timeUnit: 'yearmonth'
+      }));
+    });
+
+    it('should return false when at least 1 part of a multi-part timeUnit does not have at least 2 distinct values', () => {
+      const variationData = [
+        {a: 'Jan 1, 2000'},
+        {a: 'Jan 1, 2001'}
+      ];
+      const variationSchema = Schema.build(variationData);
+      assert.isFalse(variationSchema.timeUnitHasVariation({
+        field: 'a',
+        channel: Channel.X,
+        timeUnit: 'yearmonth'
+      }));
+    });
+
+    it('should return false when date has no variation but day does have variation and the `day` unit is used', () => {
+      const variationData = [
+        {a: 'Jan 1, 2000'}, // saturday
+        {a: 'Feb 1, 2000'}  // tuesday
+      ];
+      const variationSchema = Schema.build(variationData);
+      assert.isFalse(variationSchema.timeUnitHasVariation({
+        field: 'a',
+        channel: Channel.X,
+        timeUnit: 'day'
+      }));
+    });
+  });
+
   describe('stats', () => {
     it('should return null for an EncodingQuery whose field does not exist in the schema', () => {
       const summary: Summary = schema.stats({field: 'foo', channel: Channel.X});


### PR DESCRIPTION
Add method `timeUnitHasVariation`. Returns true if the number of dates that are completely distinct in all "parts" of the timeUnit is greater than 1.

Part of a follow up to https://github.com/uwdata/voyager2/issues/93. 