### PR TITLE
Extend orderBy, chooseBy, orderGroupBy to support array

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -753,10 +753,10 @@ export class SpecQueryModelGroup {
   private _path: string;
   private _items: (SpecQueryModel | SpecQueryModelGroup)[];
   private _groupBy: GroupBy;
-  private _orderGroupBy: string;
+  private _orderGroupBy: string | string[];
 
   constructor(name: string = '', path: string = '', items: (SpecQueryModel | SpecQueryModelGroup)[] = [],
-              groupBy: GroupBy = undefined, orderGroupBy: string = undefined) {
+              groupBy: GroupBy = undefined, orderGroupBy: string | string[] = undefined) {
     this._name = name;
     this._path = path;
     this._items = items;
@@ -793,7 +793,7 @@ export class SpecQueryModelGroup {
     return this._orderGroupBy;
   }
 
-  public set orderGroupBy(orderGroupBy: string) {
+  public set orderGroupBy(orderGroupBy: string | string[]) {
     this._orderGroupBy = orderGroupBy;
   }
 }

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -70,12 +70,12 @@ export interface Query {
   spec: SpecQuery;
   nest?: Nest[];
   groupBy?: GroupBy;
-  orderBy?: string;
-  chooseBy?: string;
+  orderBy?: string | string[];
+  chooseBy?: string | string[];
   config?: QueryConfig;
 }
 
 export interface Nest {
   groupBy: GroupBy;
-  orderGroupBy?: string;
+  orderGroupBy?: string | string[];
 }

--- a/src/ranking/ranking.ts
+++ b/src/ranking/ranking.ts
@@ -85,18 +85,38 @@ function getScore(model: SpecQueryModel, rankingName: string, schema: Schema, op
   return score;
 }
 
-export function comparator(name: string, schema: Schema, opt: QueryConfig) {
+export function comparator(name: string | string[], schema: Schema, opt: QueryConfig) {
   return (m1: SpecQueryModel, m2: SpecQueryModel) => {
-    return getScore(m2, name, schema, opt).score - getScore(m1, name, schema, opt).score;
+    if (name instanceof Array) {
+      return getScoreDifference(name, m1, m2, schema, opt);
+
+    } else {
+      return getScore(m2, name, schema, opt).score - getScore(m1, name, schema, opt).score;
+    }
   };
 }
 
-export function groupComparator(name: string, schema: Schema, opt: QueryConfig) {
+export function groupComparator(name: string | string[], schema: Schema, opt: QueryConfig) {
   return (g1: SpecQueryModelGroup, g2: SpecQueryModelGroup) => {
     const m1 = g1.getTopSpecQueryModel();
     const m2 = g2.getTopSpecQueryModel();
-    return getScore(m2, name, schema, opt).score - getScore(m1, name, schema, opt).score;
+    if (name instanceof Array) {
+      return getScoreDifference(name, m1, m2, schema, opt);
+    } else {
+      return getScore(m2, name, schema, opt).score - getScore(m1, name, schema, opt).score;
+    }
   };
+}
+
+function getScoreDifference(name: string[], m1: SpecQueryModel, m2: SpecQueryModel, schema, opt): number {
+    let scoreDifference = getScore(m2, name[0], schema, opt).score - getScore(m1, name[0], schema, opt).score;
+    for (let i = 1; i < name.length; i++) {
+      if (scoreDifference !== 0) {
+        break;
+      }
+      scoreDifference = getScore(m2, name[i], schema, opt).score - getScore(m1, name[i], schema, opt).score;
+    }
+    return scoreDifference;
 }
 
 export const EFFECTIVENESS = 'effectiveness';

--- a/src/ranking/ranking.ts
+++ b/src/ranking/ranking.ts
@@ -89,7 +89,6 @@ export function comparator(name: string | string[], schema: Schema, opt: QueryCo
   return (m1: SpecQueryModel, m2: SpecQueryModel) => {
     if (name instanceof Array) {
       return getScoreDifference(name, m1, m2, schema, opt);
-
     } else {
       return getScore(m2, name, schema, opt).score - getScore(m1, name, schema, opt).score;
     }

--- a/src/ranking/ranking.ts
+++ b/src/ranking/ranking.ts
@@ -75,7 +75,7 @@ export function rank(group: SpecQueryModelGroup, query: Query, schema: Schema, l
   return group;
 }
 
-function getScore(model: SpecQueryModel, rankingName: string, schema: Schema, opt: QueryConfig) {
+export function getScore(model: SpecQueryModel, rankingName: string, schema: Schema, opt: QueryConfig) {
   if (model.getRankingScore(rankingName) !== undefined) {
     return model.getRankingScore(rankingName);
   }

--- a/src/ranking/ranking.ts
+++ b/src/ranking/ranking.ts
@@ -55,7 +55,7 @@ export function get(name: string) {
 export function rank(group: SpecQueryModelGroup, query: Query, schema: Schema, level: number) {
   if (!query.nest || level === query.nest.length) {
     if (query.orderBy || query.chooseBy) {
-      group.items.sort(comparator(query.orderBy || query.chooseBy, schema, query.config));
+      group.items.sort(comparatorFactory(query.orderBy || query.chooseBy, schema, query.config));
       if (query.chooseBy) {
         if (group.items.length > 0) {
           // for chooseBy -- only keep the top-item
@@ -69,7 +69,7 @@ export function rank(group: SpecQueryModelGroup, query: Query, schema: Schema, l
       rank(subgroup as SpecQueryModelGroup, query, schema, level + 1);
     });
     if (query.nest[level].orderGroupBy) {
-      group.items.sort(groupComparator(query.nest[level].orderGroupBy, schema, query.config));
+      group.items.sort(groupComparatorFactory(query.nest[level].orderGroupBy, schema, query.config));
     }
   }
   return group;
@@ -85,7 +85,7 @@ function getScore(model: SpecQueryModel, rankingName: string, schema: Schema, op
   return score;
 }
 
-export function comparator(name: string | string[], schema: Schema, opt: QueryConfig) {
+export function comparatorFactory(name: string | string[], schema: Schema, opt: QueryConfig) {
   return (m1: SpecQueryModel, m2: SpecQueryModel) => {
     if (name instanceof Array) {
       return getScoreDifference(name, m1, m2, schema, opt);
@@ -95,7 +95,7 @@ export function comparator(name: string | string[], schema: Schema, opt: QueryCo
   };
 }
 
-export function groupComparator(name: string | string[], schema: Schema, opt: QueryConfig) {
+export function groupComparatorFactory(name: string | string[], schema: Schema, opt: QueryConfig) {
   return (g1: SpecQueryModelGroup, g2: SpecQueryModelGroup) => {
     const m1 = g1.getTopSpecQueryModel();
     const m2 = g2.getTopSpecQueryModel();

--- a/src/ranking/ranking.ts
+++ b/src/ranking/ranking.ts
@@ -108,14 +108,13 @@ export function groupComparator(name: string | string[], schema: Schema, opt: Qu
 }
 
 function getScoreDifference(name: string[], m1: SpecQueryModel, m2: SpecQueryModel, schema, opt): number {
-    let scoreDifference = getScore(m2, name[0], schema, opt).score - getScore(m1, name[0], schema, opt).score;
-    for (let i = 1; i < name.length; i++) {
-      if (scoreDifference !== 0) {
-        break;
-      }
-      scoreDifference = getScore(m2, name[i], schema, opt).score - getScore(m1, name[i], schema, opt).score;
+  for (let i = 0; i < name.length; i++) {
+    let scoreDifference = getScore(m2, name[i], schema, opt).score - getScore(m1, name[i], schema, opt).score;
+    if (scoreDifference !== 0) {
+      return scoreDifference;
     }
-    return scoreDifference;
+  }
+  return 0;
 }
 
 export const EFFECTIVENESS = 'effectiveness';

--- a/test/query/query.test.ts
+++ b/test/query/query.test.ts
@@ -143,8 +143,13 @@ describe('query/query', () => {
           let currentItem = result.items[i];
 
           assert.isTrue(
-            getScore(previousItem as SpecQueryModel, 'aggregationQuality', schema, DEFAULT_QUERY_CONFIG).score >=
-            getScore(currentItem as SpecQueryModel, 'aggregationQuality', schema, DEFAULT_QUERY_CONFIG).score
+            (getScore(previousItem as SpecQueryModel, 'aggregationQuality', schema, DEFAULT_QUERY_CONFIG).score >=
+            getScore(currentItem as SpecQueryModel, 'aggregationQuality', schema, DEFAULT_QUERY_CONFIG).score) ||
+
+            ((getScore(previousItem as SpecQueryModel, 'aggregationQuality', schema, DEFAULT_QUERY_CONFIG).score ===
+            getScore(currentItem as SpecQueryModel, 'aggregationQuality', schema, DEFAULT_QUERY_CONFIG).score) &&
+            (getScore(previousItem as SpecQueryModel, 'effectiveness', schema, DEFAULT_QUERY_CONFIG).score >=
+            getScore(currentItem as SpecQueryModel, 'effectiveness', schema, DEFAULT_QUERY_CONFIG).score))
           );
         }
       });

--- a/test/query/query.test.ts
+++ b/test/query/query.test.ts
@@ -123,18 +123,18 @@ describe('query/query', () => {
     });
 
     describe('rank', () => {
-      const q: Query = {
-        spec: {
-          mark: '?',
-          encodings: [
-            {channel: '?', bin: '?', aggregate: '?', field: 'Q', type: Type.QUANTITATIVE},
-            {channel: '?', bin: '?', aggregate: '?', field: 'Q1', type: Type.QUANTITATIVE}
-          ]
-        },
-       orderBy: ['aggregationQuality', 'effectiveness']
-      };
-
       it('should return a sorted SpecQueryModelGroup when passed a query with orderBy array', () => {
+        const q: Query = {
+          spec: {
+            mark: '?',
+            encodings: [
+              {channel: '?', bin: '?', aggregate: '?', field: 'Q', type: Type.QUANTITATIVE},
+              {channel: '?', bin: '?', aggregate: '?', field: 'Q1', type: Type.QUANTITATIVE}
+            ]
+          },
+        orderBy: ['aggregationQuality', 'effectiveness']
+        };
+
         const output = query(q, schema);
         const result = output.result;
 

--- a/test/query/query.test.ts
+++ b/test/query/query.test.ts
@@ -123,7 +123,7 @@ describe('query/query', () => {
     });
 
     describe('rank', () => {
-      it('should return a sorted SpecQueryModelGroup when passed a query with orderBy array', () => {
+      it('should sort SpecQueryModelGroup\'s items when passed orderBy is an array', () => {
         const q: Query = {
           spec: {
             mark: '?',
@@ -132,24 +132,27 @@ describe('query/query', () => {
               {channel: '?', bin: '?', aggregate: '?', field: 'Q1', type: Type.QUANTITATIVE}
             ]
           },
-        orderBy: ['aggregationQuality', 'effectiveness']
+          orderBy: ['aggregationQuality', 'effectiveness']
         };
 
         const output = query(q, schema);
         const result = output.result;
 
+        function score(item: any, rankingName: string) {
+          return getScore(item, rankingName, schema, DEFAULT_QUERY_CONFIG);
+        }
+
         for (let i = 1; i < result.items.length; i++) {
-          let previousItem = result.items[i-1];
-          let currentItem = result.items[i];
+          let prev = result.items[i-1];
+          let cur = result.items[i];
+
 
           assert.isTrue(
-            (getScore(previousItem as SpecQueryModel, 'aggregationQuality', schema, DEFAULT_QUERY_CONFIG).score >=
-            getScore(currentItem as SpecQueryModel, 'aggregationQuality', schema, DEFAULT_QUERY_CONFIG).score) ||
-
-            ((getScore(previousItem as SpecQueryModel, 'aggregationQuality', schema, DEFAULT_QUERY_CONFIG).score ===
-            getScore(currentItem as SpecQueryModel, 'aggregationQuality', schema, DEFAULT_QUERY_CONFIG).score) &&
-            (getScore(previousItem as SpecQueryModel, 'effectiveness', schema, DEFAULT_QUERY_CONFIG).score >=
-            getScore(currentItem as SpecQueryModel, 'effectiveness', schema, DEFAULT_QUERY_CONFIG).score))
+            score(prev, 'aggregationQuality') >= score(cur, 'aggregationQuality') ||
+            (
+              score(prev, 'aggregationQuality') === score(cur, 'aggregationQuality') &&
+              score(prev, 'effectiveness') >= score(cur, 'effectiveness')
+            )
           );
         }
       });

--- a/test/ranking/ranking.test.ts
+++ b/test/ranking/ranking.test.ts
@@ -5,10 +5,7 @@ import {Type} from 'vega-lite/src/type';
 import {schema} from '../fixture';
 
 import {DEFAULT_QUERY_CONFIG} from '../../src/config';
-import {SHORT_ENUM_SPEC} from '../../src/enumspec';
-import {generate} from '../../src/generate';
-import {SpecQueryModelGroup} from '../../src/model';
-import {SpecQuery} from '../../src/query/spec';
+import {SpecQueryModel, SpecQueryModelGroup} from '../../src/model';
 import {rank, comparatorFactory} from '../../src/ranking/ranking';
 
 import {assert} from 'chai';
@@ -37,53 +34,61 @@ describe('ranking', () => {
 
   describe('comparatorFactory', () => {
     it('should create a comparator that returns a score difference when passed an orderBy array', () => {
-      const specQ: SpecQuery = {
-        mark: SHORT_ENUM_SPEC,
-        encodings: [
-          {
-            channel: SHORT_ENUM_SPEC,
-            bin: SHORT_ENUM_SPEC,
-            aggregate: SHORT_ENUM_SPEC,
-            field: 'Q',
-            type: Type.QUANTITATIVE
-          },
-          {
-            channel: SHORT_ENUM_SPEC,
-            bin: SHORT_ENUM_SPEC,
-            aggregate: SHORT_ENUM_SPEC,
-            field: 'Q1',
-            type: Type.QUANTITATIVE
-          }
-        ]
-      };
-      const answerSet = generate(specQ, schema, DEFAULT_QUERY_CONFIG);
+      const specM1 = SpecQueryModel.build(
+        {
+          mark: Mark.POINT,
+          encodings: [
+            {channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
+            {channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE},
+          ]
+        },
+        schema,
+        DEFAULT_QUERY_CONFIG
+      );
+
+      const specM2 = SpecQueryModel.build(
+        {
+          mark: Mark.BAR,
+          encodings: [
+            {channel: Channel.X, field: 'N', type: Type.NOMINAL},
+            {channel: Channel.Y, field: 'Q', type: Type.QUANTITATIVE},
+          ]
+        },
+        schema,
+        DEFAULT_QUERY_CONFIG
+      );
+
       const comparator = comparatorFactory(['aggregationQuality', 'effectiveness'], schema, DEFAULT_QUERY_CONFIG);
-      assert.isNumber(comparator(answerSet[1], answerSet[4]));
+      assert.isNumber(comparator(specM1, specM2));
     });
 
     it('should create a comparator that returns a score difference when passed an orderBy string', () => {
-      const specQ: SpecQuery = {
-        mark: SHORT_ENUM_SPEC,
-        encodings: [
-          {
-            channel: SHORT_ENUM_SPEC,
-            bin: SHORT_ENUM_SPEC,
-            aggregate: SHORT_ENUM_SPEC,
-            field: 'Q',
-            type: Type.QUANTITATIVE
-          },
-          {
-            channel: SHORT_ENUM_SPEC,
-            bin: SHORT_ENUM_SPEC,
-            aggregate: SHORT_ENUM_SPEC,
-            field: 'Q1',
-            type: Type.QUANTITATIVE
-          }
-        ]
-      };
-      const answerSet = generate(specQ, schema, DEFAULT_QUERY_CONFIG);
+      const specM1 = SpecQueryModel.build(
+        {
+          mark: Mark.POINT,
+          encodings: [
+            {channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
+            {channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE},
+          ]
+        },
+        schema,
+        DEFAULT_QUERY_CONFIG
+      );
+
+      const specM2 = SpecQueryModel.build(
+        {
+          mark: Mark.BAR,
+          encodings: [
+            {channel: Channel.X, field: 'N', type: Type.NOMINAL},
+            {channel: Channel.Y, field: 'Q', type: Type.QUANTITATIVE},
+          ]
+        },
+        schema,
+        DEFAULT_QUERY_CONFIG
+      );
+
       const comparator = comparatorFactory('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
-      assert.isNumber(comparator(answerSet[1], answerSet[4]));
+      assert.isNumber(comparator(specM1, specM2));
     });
   });
 });

--- a/test/ranking/ranking.test.ts
+++ b/test/ranking/ranking.test.ts
@@ -1,8 +1,8 @@
 import {AggregateOp} from 'vega-lite/src/aggregate';
 import {Channel} from 'vega-lite/src/channel';
 import {Mark} from 'vega-lite/src/mark';
-import {Type} from 'vega-lite/src/type';
 import {TimeUnit} from 'vega-lite/src/timeunit';
+import {Type} from 'vega-lite/src/type';
 
 import {schema} from '../fixture';
 

--- a/test/ranking/ranking.test.ts
+++ b/test/ranking/ranking.test.ts
@@ -4,8 +4,12 @@ import {Type} from 'vega-lite/src/type';
 
 import {schema} from '../fixture';
 
+import {DEFAULT_QUERY_CONFIG} from '../../src/config';
+import {SHORT_ENUM_SPEC} from '../../src/enumspec';
+import {generate} from '../../src/generate';
 import {SpecQueryModelGroup} from '../../src/model';
-import {rank} from '../../src/ranking/ranking';
+import {SpecQuery} from '../../src/query/spec';
+import {rank, comparator} from '../../src/ranking/ranking';
 
 import {assert} from 'chai';
 
@@ -28,6 +32,58 @@ describe('ranking', () => {
         0
       );
       assert.deepEqual(group.items, []);
+    });
+  });
+
+  describe('comparator', () => {
+    it('should return a score difference when passed an orderBy array', () => {
+      const specQ: SpecQuery = {
+        mark: SHORT_ENUM_SPEC,
+        encodings: [
+          {
+            channel: SHORT_ENUM_SPEC,
+            bin: SHORT_ENUM_SPEC,
+            aggregate: SHORT_ENUM_SPEC,
+            field: 'Q',
+            type: Type.QUANTITATIVE
+          },
+          {
+            channel: SHORT_ENUM_SPEC,
+            bin: SHORT_ENUM_SPEC,
+            aggregate: SHORT_ENUM_SPEC,
+            field: 'Q1',
+            type: Type.QUANTITATIVE
+          }
+        ]
+      };
+      const answerSet = generate(specQ, schema, DEFAULT_QUERY_CONFIG);
+      const testComparator = comparator(['aggregationQuality', 'effectiveness'], schema, DEFAULT_QUERY_CONFIG);
+      assert.isNumber(testComparator(answerSet[1], answerSet[4]));
+    });
+
+    it('should return a score difference when passed an orderBy string', () => {
+      const specQ: SpecQuery = {
+        mark: SHORT_ENUM_SPEC,
+        encodings: [
+          {
+            channel: SHORT_ENUM_SPEC,
+            bin: SHORT_ENUM_SPEC,
+            aggregate: SHORT_ENUM_SPEC,
+            field: 'Q',
+            type: Type.QUANTITATIVE
+          },
+          {
+            channel: SHORT_ENUM_SPEC,
+            bin: SHORT_ENUM_SPEC,
+            aggregate: SHORT_ENUM_SPEC,
+            field: 'Q1',
+            type: Type.QUANTITATIVE
+          }
+        ]
+      };
+      const answerSet = generate(specQ, schema, DEFAULT_QUERY_CONFIG);
+      const testComparator = comparator('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
+      assert.isNumber(testComparator(answerSet[1], answerSet[4]));
     });
   });
 });

--- a/test/ranking/ranking.test.ts
+++ b/test/ranking/ranking.test.ts
@@ -54,7 +54,7 @@ describe('ranking', () => {
         {
           mark: Mark.POINT,
           encodings: [
-            {channel: Channel.X, field: 'date', type: Type.TEMPORAL},
+            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
             {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
             {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
           ]
@@ -65,6 +65,37 @@ describe('ranking', () => {
 
       const comparator = comparatorFactory(['aggregationQuality', 'effectiveness'], schema, DEFAULT_QUERY_CONFIG);
       assert.isBelow(comparator(specM1, specM2), 0);
+    });
+
+    it('should create a comparator that returns a value of 0 when the orderBy ranker results in a tie', () => {
+      const specM1 = SpecQueryModel.build(
+        {
+          mark: Mark.LINE,
+          encodings: [
+            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
+            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
+          ]
+        },
+        schema,
+        DEFAULT_QUERY_CONFIG
+      );
+
+      const specM2 = SpecQueryModel.build(
+        {
+          mark: Mark.POINT,
+          encodings: [
+            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
+            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
+          ]
+        },
+        schema,
+        DEFAULT_QUERY_CONFIG
+      );
+
+      const comparator = comparatorFactory('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
+      assert.equal(comparator(specM1, specM2), 0);
     });
 
     it('should create a comparator that correctly sorts two spec when passed an orderBy string of effectiveness', () => {
@@ -124,7 +155,7 @@ describe('ranking', () => {
       );
 
       const comparator = comparatorFactory('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
-      assert.isTrue(comparator(specM1, specM2) < 0);
+      assert.isBelow(comparator(specM1, specM2), 0);
     });
   });
 });

--- a/test/ranking/ranking.test.ts
+++ b/test/ranking/ranking.test.ts
@@ -9,7 +9,7 @@ import {SHORT_ENUM_SPEC} from '../../src/enumspec';
 import {generate} from '../../src/generate';
 import {SpecQueryModelGroup} from '../../src/model';
 import {SpecQuery} from '../../src/query/spec';
-import {rank, comparator} from '../../src/ranking/ranking';
+import {rank, comparatorFactory} from '../../src/ranking/ranking';
 
 import {assert} from 'chai';
 
@@ -35,7 +35,7 @@ describe('ranking', () => {
     });
   });
 
-  describe('comparator', () => {
+  describe('comparatorFactory', () => {
     it('should return a score difference when passed an orderBy array', () => {
       const specQ: SpecQuery = {
         mark: SHORT_ENUM_SPEC,
@@ -57,8 +57,8 @@ describe('ranking', () => {
         ]
       };
       const answerSet = generate(specQ, schema, DEFAULT_QUERY_CONFIG);
-      const testComparator = comparator(['aggregationQuality', 'effectiveness'], schema, DEFAULT_QUERY_CONFIG);
-      assert.isNumber(testComparator(answerSet[1], answerSet[4]));
+      const comparator = comparatorFactory(['aggregationQuality', 'effectiveness'], schema, DEFAULT_QUERY_CONFIG);
+      assert.isNumber(comparator(answerSet[1], answerSet[4]));
     });
 
     it('should return a score difference when passed an orderBy string', () => {
@@ -82,8 +82,8 @@ describe('ranking', () => {
         ]
       };
       const answerSet = generate(specQ, schema, DEFAULT_QUERY_CONFIG);
-      const testComparator = comparator('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
-      assert.isNumber(testComparator(answerSet[1], answerSet[4]));
+      const comparator = comparatorFactory('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
+      assert.isNumber(comparator(answerSet[1], answerSet[4]));
     });
   });
 });

--- a/test/ranking/ranking.test.ts
+++ b/test/ranking/ranking.test.ts
@@ -35,127 +35,126 @@ describe('ranking', () => {
   });
 
   describe('comparatorFactory', () => {
-    it('should create a comparator that uses the second ranker of an orderBy array to sort two spec ' +
+    describe('nested / multiple ranking', () => {
+      it('should create a comparator that uses the second ranker of an orderBy array to specs ' +
        'if the first ranker results in a tie', () => {
-      const specM1 = SpecQueryModel.build(
-        {
-          mark: Mark.LINE,
-          encodings: [
-            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
-            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
-            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
-          ]
-        },
-        schema,
-        DEFAULT_QUERY_CONFIG
-      );
+        const specM1 = SpecQueryModel.build(
+          {
+            mark: Mark.LINE,
+            encodings: [
+              {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
+              {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            ]
+          },
+          schema,
+          DEFAULT_QUERY_CONFIG
+        );
 
-      const specM2 = SpecQueryModel.build(
-        {
-          mark: Mark.POINT,
-          encodings: [
-            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
-            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
-            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
-          ]
-        },
-        schema,
-        DEFAULT_QUERY_CONFIG
-      );
+        const specM2 = SpecQueryModel.build(
+          {
+            mark: Mark.POINT,
+            encodings: [
+              {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
+              {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            ]
+          },
+          schema,
+          DEFAULT_QUERY_CONFIG
+        );
 
-      const comparator = comparatorFactory(['aggregationQuality', 'effectiveness'], schema, DEFAULT_QUERY_CONFIG);
-      assert.isBelow(comparator(specM1, specM2), 0);
+        const comparator = comparatorFactory(['aggregationQuality', 'effectiveness'], schema, DEFAULT_QUERY_CONFIG);
+        assert.isBelow(comparator(specM1, specM2), 0);
+      });
+
+      it('should create a comparator that uses the first orderBy to sort specs ' +
+       'if the first ranker does not produce a tie', () => {
+        const specM1 = SpecQueryModel.build(
+          {
+            mark: Mark.POINT,
+            encodings: [
+              {channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
+              {channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE},
+            ]
+          },
+          schema,
+          DEFAULT_QUERY_CONFIG
+        );
+
+        const specM2 = SpecQueryModel.build(
+          {
+            mark: Mark.POINT,
+            encodings: [
+              {aggregate: AggregateOp.MEAN, channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
+              {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE},
+            ]
+          },
+          schema,
+          DEFAULT_QUERY_CONFIG
+        );
+
+        const comparator = comparatorFactory(['aggregationQuality', 'effectiveness'], schema, DEFAULT_QUERY_CONFIG);
+        assert.isBelow(comparator(specM1, specM2), 0);
+      });
     });
 
-    it('should create a comparator that returns a value of 0 when the orderBy ranker results in a tie', () => {
-      const specM1 = SpecQueryModel.build(
-        {
-          mark: Mark.LINE,
-          encodings: [
-            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
-            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
-            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
-          ]
-        },
-        schema,
-        DEFAULT_QUERY_CONFIG
-      );
+    describe('single ranking', () => {
+      it('should create a comparator that returns a value of 0 when the orderBy ranker results in a tie', () => {
+        const specM1 = SpecQueryModel.build(
+          {
+            mark: Mark.LINE,
+            encodings: [
+              {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
+              {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE}
+            ]
+          },
+          schema,
+          DEFAULT_QUERY_CONFIG
+        );
 
-      const specM2 = SpecQueryModel.build(
-        {
-          mark: Mark.POINT,
-          encodings: [
-            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
-            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
-            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
-          ]
-        },
-        schema,
-        DEFAULT_QUERY_CONFIG
-      );
+        const specM2 = SpecQueryModel.build(
+          {
+            mark: Mark.POINT,
+            encodings: [
+              {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
+              {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE}
+            ]
+          },
+          schema,
+          DEFAULT_QUERY_CONFIG
+        );
 
-      const comparator = comparatorFactory('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
-      assert.equal(comparator(specM1, specM2), 0);
-    });
+        const comparator = comparatorFactory('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
+        assert.equal(comparator(specM1, specM2), 0);
+      });
 
-    it('should create a comparator that correctly sorts two spec when passed an orderBy string of effectiveness', () => {
-      const specM1 = SpecQueryModel.build(
-        {
-          mark: Mark.LINE,
-          encodings: [
-            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
-            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
-            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
-          ]
-        },
-        schema,
-        DEFAULT_QUERY_CONFIG
-      );
+      it('should create a comparator that correctly sorts two spec when passed an orderBy string of aggregationQuality', () => {
+        const specM1 = SpecQueryModel.build(
+          {
+            mark: Mark.POINT,
+            encodings: [
+              {channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
+              {channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE},
+            ]
+          },
+          schema,
+          DEFAULT_QUERY_CONFIG
+        );
 
-      const specM2 = SpecQueryModel.build(
-        {
-          mark: Mark.POINT,
-          encodings: [
-            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
-            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
-            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
-          ]
-        },
-        schema,
-        DEFAULT_QUERY_CONFIG
-      );
+        const specM2 = SpecQueryModel.build(
+          {
+            mark: Mark.POINT,
+            encodings: [
+              {aggregate: AggregateOp.MEAN, channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
+              {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE},
+            ]
+          },
+          schema,
+          DEFAULT_QUERY_CONFIG
+        );
 
-      const comparator = comparatorFactory('effectiveness', schema, DEFAULT_QUERY_CONFIG);
-      assert.isBelow(comparator(specM1, specM2), 0);
-    });
-
-    it('should create a comparator that correctly sorts two spec when passed an orderBy string of aggregationQuality', () => {
-      const specM1 = SpecQueryModel.build(
-        {
-          mark: Mark.POINT,
-          encodings: [
-            {channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
-            {channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE},
-          ]
-        },
-        schema,
-        DEFAULT_QUERY_CONFIG
-      );
-
-      const specM2 = SpecQueryModel.build(
-        {
-          mark: Mark.POINT,
-          encodings: [
-            {aggregate: AggregateOp.MEAN, channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
-            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE},
-          ]
-        },
-        schema,
-        DEFAULT_QUERY_CONFIG
-      );
-
-      const comparator = comparatorFactory('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
-      assert.isBelow(comparator(specM1, specM2), 0);
+        const comparator = comparatorFactory('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
+        assert.isBelow(comparator(specM1, specM2), 0);
+      });
     });
   });
 });

--- a/test/ranking/ranking.test.ts
+++ b/test/ranking/ranking.test.ts
@@ -2,6 +2,7 @@ import {AggregateOp} from 'vega-lite/src/aggregate';
 import {Channel} from 'vega-lite/src/channel';
 import {Mark} from 'vega-lite/src/mark';
 import {Type} from 'vega-lite/src/type';
+import {TimeUnit} from 'vega-lite/src/timeunit';
 
 import {schema} from '../fixture';
 
@@ -34,13 +35,14 @@ describe('ranking', () => {
   });
 
   describe('comparatorFactory', () => {
-    it('should create a comparator that returns a score difference when passed an orderBy array', () => {
+    it('should create a comparator that uses the second ranker of an orderBy array to sort two spec ' +
+       'if the first ranker results in a tie', () => {
       const specM1 = SpecQueryModel.build(
         {
           mark: Mark.LINE,
           encodings: [
-            {channel: Channel.X, field: 'date', type: Type.TEMPORAL},
-            {channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
+            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
             {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
           ]
         },
@@ -53,7 +55,7 @@ describe('ranking', () => {
           mark: Mark.POINT,
           encodings: [
             {channel: Channel.X, field: 'date', type: Type.TEMPORAL},
-            {channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
             {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
           ]
         },
@@ -62,16 +64,16 @@ describe('ranking', () => {
       );
 
       const comparator = comparatorFactory(['aggregationQuality', 'effectiveness'], schema, DEFAULT_QUERY_CONFIG);
-      assert.isTrue(comparator(specM1, specM2) > 0);
+      assert.isBelow(comparator(specM1, specM2), 0);
     });
 
-    it('should create a comparator that returns a score difference when passed an orderBy string of effectiveness', () => {
+    it('should create a comparator that correctly sorts two spec when passed an orderBy string of effectiveness', () => {
       const specM1 = SpecQueryModel.build(
         {
           mark: Mark.LINE,
           encodings: [
-            {channel: Channel.X, field: 'date', type: Type.TEMPORAL},
-            {channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
+            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
             {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
           ]
         },
@@ -83,8 +85,8 @@ describe('ranking', () => {
         {
           mark: Mark.POINT,
           encodings: [
-            {channel: Channel.X, field: 'date', type: Type.TEMPORAL},
-            {channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            {channel: Channel.X, field: 'date', type: Type.TEMPORAL, timeUnit: TimeUnit.DAY},
+            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
             {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
           ]
         },
@@ -93,10 +95,10 @@ describe('ranking', () => {
       );
 
       const comparator = comparatorFactory('effectiveness', schema, DEFAULT_QUERY_CONFIG);
-      assert.isTrue(comparator(specM1, specM2) > 0);
+      assert.isBelow(comparator(specM1, specM2), 0);
     });
 
-    it('should create a comparator that returns a score difference when passed an orderBy string of aggregationQuality', () => {
+    it('should create a comparator that correctly sorts two spec when passed an orderBy string of aggregationQuality', () => {
       const specM1 = SpecQueryModel.build(
         {
           mark: Mark.POINT,

--- a/test/ranking/ranking.test.ts
+++ b/test/ranking/ranking.test.ts
@@ -34,7 +34,7 @@ describe('ranking', () => {
   });
 
   describe('comparatorFactory', () => {
-    it.only('should create a comparator that returns a score difference when passed an orderBy array', () => {
+    it('should create a comparator that returns a score difference when passed an orderBy array', () => {
       const specM1 = SpecQueryModel.build(
         {
           mark: Mark.LINE,

--- a/test/ranking/ranking.test.ts
+++ b/test/ranking/ranking.test.ts
@@ -36,7 +36,7 @@ describe('ranking', () => {
   });
 
   describe('comparatorFactory', () => {
-    it('should return a score difference when passed an orderBy array', () => {
+    it('should create a comparator that returns a score difference when passed an orderBy array', () => {
       const specQ: SpecQuery = {
         mark: SHORT_ENUM_SPEC,
         encodings: [
@@ -61,7 +61,7 @@ describe('ranking', () => {
       assert.isNumber(comparator(answerSet[1], answerSet[4]));
     });
 
-    it('should return a score difference when passed an orderBy string', () => {
+    it('should create a comparator that returns a score difference when passed an orderBy string', () => {
       const specQ: SpecQuery = {
         mark: SHORT_ENUM_SPEC,
         encodings: [

--- a/test/ranking/ranking.test.ts
+++ b/test/ranking/ranking.test.ts
@@ -1,3 +1,4 @@
+import {AggregateOp} from 'vega-lite/src/aggregate';
 import {Channel} from 'vega-lite/src/channel';
 import {Mark} from 'vega-lite/src/mark';
 import {Type} from 'vega-lite/src/type';
@@ -33,13 +34,14 @@ describe('ranking', () => {
   });
 
   describe('comparatorFactory', () => {
-    it('should create a comparator that returns a score difference when passed an orderBy array', () => {
+    it.only('should create a comparator that returns a score difference when passed an orderBy array', () => {
       const specM1 = SpecQueryModel.build(
         {
-          mark: Mark.POINT,
+          mark: Mark.LINE,
           encodings: [
-            {channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
-            {channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE},
+            {channel: Channel.X, field: 'date', type: Type.TEMPORAL},
+            {channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
           ]
         },
         schema,
@@ -48,10 +50,11 @@ describe('ranking', () => {
 
       const specM2 = SpecQueryModel.build(
         {
-          mark: Mark.BAR,
+          mark: Mark.POINT,
           encodings: [
-            {channel: Channel.X, field: 'N', type: Type.NOMINAL},
-            {channel: Channel.Y, field: 'Q', type: Type.QUANTITATIVE},
+            {channel: Channel.X, field: 'date', type: Type.TEMPORAL},
+            {channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
           ]
         },
         schema,
@@ -59,10 +62,41 @@ describe('ranking', () => {
       );
 
       const comparator = comparatorFactory(['aggregationQuality', 'effectiveness'], schema, DEFAULT_QUERY_CONFIG);
-      assert.isNumber(comparator(specM1, specM2));
+      assert.isTrue(comparator(specM1, specM2) > 0);
     });
 
-    it('should create a comparator that returns a score difference when passed an orderBy string', () => {
+    it('should create a comparator that returns a score difference when passed an orderBy string of effectiveness', () => {
+      const specM1 = SpecQueryModel.build(
+        {
+          mark: Mark.LINE,
+          encodings: [
+            {channel: Channel.X, field: 'date', type: Type.TEMPORAL},
+            {channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
+          ]
+        },
+        schema,
+        DEFAULT_QUERY_CONFIG
+      );
+
+      const specM2 = SpecQueryModel.build(
+        {
+          mark: Mark.POINT,
+          encodings: [
+            {channel: Channel.X, field: 'date', type: Type.TEMPORAL},
+            {channel: Channel.Y, field: 'price', type: Type.QUANTITATIVE},
+            {channel: Channel.COLOR, field: 'symbol', type: Type.NOMINAL}
+          ]
+        },
+        schema,
+        DEFAULT_QUERY_CONFIG
+      );
+
+      const comparator = comparatorFactory('effectiveness', schema, DEFAULT_QUERY_CONFIG);
+      assert.isTrue(comparator(specM1, specM2) > 0);
+    });
+
+    it('should create a comparator that returns a score difference when passed an orderBy string of aggregationQuality', () => {
       const specM1 = SpecQueryModel.build(
         {
           mark: Mark.POINT,
@@ -77,10 +111,10 @@ describe('ranking', () => {
 
       const specM2 = SpecQueryModel.build(
         {
-          mark: Mark.BAR,
+          mark: Mark.POINT,
           encodings: [
-            {channel: Channel.X, field: 'N', type: Type.NOMINAL},
-            {channel: Channel.Y, field: 'Q', type: Type.QUANTITATIVE},
+            {aggregate: AggregateOp.MEAN, channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE},
+            {aggregate: AggregateOp.MEAN, channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE},
           ]
         },
         schema,
@@ -88,7 +122,7 @@ describe('ranking', () => {
       );
 
       const comparator = comparatorFactory('aggregationQuality', schema, DEFAULT_QUERY_CONFIG);
-      assert.isNumber(comparator(specM1, specM2));
+      assert.isTrue(comparator(specM1, specM2) < 0);
     });
   });
 });


### PR DESCRIPTION
Fix #195 
- Support string array type for orderBy, chooseBy, and orderGroupBy