### PR TITLE
[WIP] Relax channel related constraints

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -170,6 +170,7 @@ export interface QueryConfig {
   autoAddCount?: boolean;
 
   // CONSTRAINTS
+  constraintManuallySpecifiedValue?: boolean;
   // Spec Constraints
 
   hasAppropriateGraphicTypeForMark?: boolean;
@@ -301,6 +302,7 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
   numberOrdinalLimit: 50,
 
   // CONSTRAINTS
+  constraintManuallySpecifiedValue: false,
   // Spec Constraints -- See description inside src/constraints/spec.ts
   autoAddCount: false,
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -179,14 +179,13 @@ export interface QueryConfig {
   omitAggregatePlotWithoutDimension?: boolean;
   omitBarLineAreaWithOcclusion?: boolean;
   omitBarTickWithSize?: boolean;
-  omitFacetOverPositionalChannels?: boolean;
   omitMultipleNonPositionalChannels?: boolean;
   omitNonSumStack?: boolean;
   omitRaw?: boolean;
   omitRawContinuousFieldForAggregatePlot?: boolean;
   omitRawWithXYBothOrdinalScaleOrBin?: boolean;
   omitRepeatedField?: boolean;
-  omitNonPositionalOverPositionalChannels?: boolean;
+  omitNonPositionalOrFacetOverPositionalChannels?: boolean;
   omitTableWithOcclusionIfAutoAddCount?: boolean;
   omitVerticalDotPlot?: boolean;
 
@@ -312,13 +311,12 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
   omitAggregatePlotWithoutDimension: false,
   omitBarLineAreaWithOcclusion: true,
   omitBarTickWithSize: true,
-  omitFacetOverPositionalChannels: true,
   omitMultipleNonPositionalChannels: true,
   omitNonSumStack: true,
   omitRaw: false,
   omitRawContinuousFieldForAggregatePlot: true,
   omitRepeatedField: true,
-  omitNonPositionalOverPositionalChannels: true,
+  omitNonPositionalOrFacetOverPositionalChannels: true,
   omitTableWithOcclusionIfAutoAddCount: true,
   omitVerticalDotPlot: false,
 

--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -475,8 +475,18 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
       if (specM.isAggregate()) {
         return true;
       }
-      return every(specM.getEncodings(), (encQ) => {
-        return encQ.channel !== Channel.DETAIL;
+      return every(specM.specQuery.encodings, (encQ, index) => {
+        if (encQ.autoCount === false) return true; // ignore autoCount field
+
+        if (encQ.channel === Channel.DETAIL) {
+          // Detail channel for raw plot is not good, except when its enumerated
+          // or when it's manually specified but we constraintManuallySpecifiedValue.
+          if (specM.enumSpecIndex.hasEncodingProperty(index, Property.CHANNEL) ||
+              opt.constraintManuallySpecifiedValue) {
+            return false;
+          }
+        }
+        return true;
       });
     }
   },

--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -109,7 +109,7 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
   },
   {
     name: 'alwaysIncludeZeroInScaleWithBarMark',
-    description: 'Do not reccommend bar mark if scale does not start at zero',
+    description: 'Do not recommend bar mark if scale does not start at zero',
     properties: [Property.MARK, Property.SCALE, Property.SCALE_ZERO, Property.CHANNEL, Property.TYPE],
     allowEnumSpecForProperties: false,
     strict: true,
@@ -122,6 +122,7 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
           if ( (encQ.channel === Channel.X || encQ.channel === Channel.Y) &&
                (encQ.type === Type.QUANTITATIVE) &&
                (encQ.scale && (encQ.scale as ScaleQuery).zero === false)) {
+            // TODO: zero shouldn't be manually specified
             return false;
           }
         }
@@ -290,6 +291,7 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
     strict: false,
     satisfy: (specM: SpecQueryModel, schema: Schema, opt: QueryConfig) => {
       if (specM.isAggregate()) {
+        // TODO relax
         return some(specM.getEncodings(), (encQ: EncodingQuery) => {
           if (isDimension(encQ)) {
             return true;
@@ -359,6 +361,7 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
       const mark = specM.getMark();
       const encodings = specM.getEncodings();
 
+      // TODO: mark or scale type should be enumerated
       if (mark === Mark.AREA || mark === Mark.BAR) {
         for (let encQ of encodings) {
           if((encQ.channel === Channel.X || encQ.channel === Channel.Y) && encQ.scale) {

--- a/src/enumspecindex.ts
+++ b/src/enumspecindex.ts
@@ -104,6 +104,10 @@ export class EnumSpecIndex {
     return this;
   }
 
+  public hasEncodingProperty(index: number, prop: Property) {
+    return !!(this._encodings[index] || {})[prop];
+  }
+
   public hasProperty(prop: Property) {
     if (isEncodingProperty(prop)) {
       return !!this.encodingIndicesByProperty[prop];

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -1087,7 +1087,21 @@ describe('constraints/spec', () => {
   });
 
   describe('omitRawContinuousFieldForAggregatePlot', () => {
-    it('should return false if the aggregate plot groups by a raw temporal field', () => {
+    it('should return false if the aggregate plot groups by a raw temporal field with timeUnit enumerated as undefined', () => {
+      const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {channel: Channel.X, aggregate: AggregateOp.MEAN, field: 'A', type: Type.NOMINAL},
+            {channel: Channel.Y, field: 'C', type: Type.TEMPORAL, timeUnit: {enum: [undefined]}}
+          ]
+        });
+
+      specM.setEncodingProperty(1, Property.TIMEUNIT, undefined, {enum: [undefined]});
+
+      assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRawContinuousFieldForAggregatePlot'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+    });
+
+    it('should return false if the aggregate plot groups by a raw temporal field with specified timeUnit = undefined', () => {
       const specM = buildSpecQueryModel({
           mark: Mark.POINT,
           encodings: [
@@ -1096,7 +1110,19 @@ describe('constraints/spec', () => {
           ]
         });
 
-      assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRawContinuousFieldForAggregatePlot'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+      assert.isTrue(SPEC_CONSTRAINT_INDEX['omitRawContinuousFieldForAggregatePlot'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+    });
+
+    it('should return false if the aggregate plot groups by a raw temporal field with specified timeUnit = undefined and we constraintManuallySpecifiedValue', () => {
+      const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {channel: Channel.X, aggregate: AggregateOp.MEAN, field: 'A', type: Type.NOMINAL},
+            {channel: Channel.Y, field: 'C', type: Type.TEMPORAL}
+          ]
+        });
+
+      assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRawContinuousFieldForAggregatePlot'].satisfy(specM, schema, CONSTRAINT_MANUALLY_SPECIFIED_CONFIG));
     });
 
     it('should return true if the aggregate plot groups by a temporal field with timeUnit', () => {
@@ -1123,7 +1149,7 @@ describe('constraints/spec', () => {
       assert.isTrue(SPEC_CONSTRAINT_INDEX['omitRawContinuousFieldForAggregatePlot'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
     });
 
-    it('should return false if the aggregate plot groups by a raw quantitative field', () => {
+    it('should return true if the aggregate plot groups by a quantitative field that is specified as raw', () => {
       const specM = buildSpecQueryModel({
           mark: Mark.POINT,
           encodings: [
@@ -1131,6 +1157,32 @@ describe('constraints/spec', () => {
             {channel: Channel.Y, field: 'C', type: Type.QUANTITATIVE}
           ]
         });
+
+      assert.isTrue(SPEC_CONSTRAINT_INDEX['omitRawContinuousFieldForAggregatePlot'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+    });
+
+    it('should return false if the aggregate plot groups by a quantitative field that is specified as raw and we constraintManuallySpecifiedValue', () => {
+      const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {channel: Channel.X, aggregate: AggregateOp.MEAN, field: 'A', type: Type.NOMINAL},
+            {channel: Channel.Y, field: 'C', type: Type.QUANTITATIVE}
+          ]
+        });
+
+      assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRawContinuousFieldForAggregatePlot'].satisfy(specM, schema, CONSTRAINT_MANUALLY_SPECIFIED_CONFIG));
+    });
+
+    it('should return false if the aggregate plot groups by a raw quantitative field that is enumerated', () => {
+      const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {channel: Channel.X, aggregate: AggregateOp.MEAN, field: 'A', type: Type.NOMINAL},
+            {channel: Channel.Y, aggregate: {enum: [undefined]}, field: 'C', type: Type.QUANTITATIVE}
+          ]
+        });
+
+      specM.setEncodingProperty(1, Property.AGGREGATE, undefined, {enum: [undefined]});
 
       assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRawContinuousFieldForAggregatePlot'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
     });

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -631,7 +631,24 @@ describe('constraints/spec', () => {
   });
 
   describe('omitBarTickWithSize', () => {
-    it('should return false if bar/tick use size', () => {
+    it('should return false if bar/tick enumerates size', () => {
+      [Mark.BAR, Mark.TICK].forEach((mark) => {
+        const specM = buildSpecQueryModel({
+          mark: mark,
+          encodings: [
+            {channel: Channel.X, field: 'N', type: Type.NOMINAL},
+            {channel: Channel.Y, field: 'Q', type: Type.QUANTITATIVE, aggregate: AggregateOp.MEAN},
+            {channel: {enum: [Channel.SIZE]}, field: 'Q1', type: Type.QUANTITATIVE, aggregate: AggregateOp.MEAN}
+          ]
+        });
+
+        specM.setEncodingProperty(2, Property.CHANNEL, Channel.SIZE, {enum: [Channel.SIZE]});
+
+        assert.isFalse(SPEC_CONSTRAINT_INDEX['omitBarTickWithSize'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+      });
+    });
+
+    it('should return true if bar/tick contains manually specified size', () => {
       [Mark.BAR, Mark.TICK].forEach((mark) => {
         const specM = buildSpecQueryModel({
           mark: mark,
@@ -642,7 +659,22 @@ describe('constraints/spec', () => {
           ]
         });
 
-        assert.isFalse(SPEC_CONSTRAINT_INDEX['omitBarTickWithSize'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+        assert.isTrue(SPEC_CONSTRAINT_INDEX['omitBarTickWithSize'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+      });
+    });
+
+    it('should return false if bar/tick contains manually specified size and we constraintManuallySpecifiedValue', () => {
+      [Mark.BAR, Mark.TICK].forEach((mark) => {
+        const specM = buildSpecQueryModel({
+          mark: mark,
+          encodings: [
+            {channel: Channel.X, field: 'N', type: Type.NOMINAL},
+            {channel: Channel.Y, field: 'Q', type: Type.QUANTITATIVE, aggregate: AggregateOp.MEAN},
+            {channel: Channel.SIZE, field: 'Q1', type: Type.QUANTITATIVE, aggregate: AggregateOp.MEAN}
+          ]
+        });
+
+        assert.isFalse(SPEC_CONSTRAINT_INDEX['omitBarTickWithSize'].satisfy(specM, schema, CONSTRAINT_MANUALLY_SPECIFIED_CONFIG));
       });
     });
 

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -948,7 +948,21 @@ describe('constraints/spec', () => {
       });
     });
 
-    it('should return false if color/shape/size is used when either x or y is not used', () => {
+    it('should return false if color/shape/size is enumerated when either x or y is not used', () => {
+      [Channel.SHAPE, Channel.SIZE, Channel.COLOR].forEach((channel) => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {channel: Channel.X, field: 'A', type: Type.NOMINAL},
+            {channel: {enum: [Channel.SHAPE, Channel.SIZE, Channel.COLOR]}, field: 'C', type: Type.NOMINAL}
+          ]
+        });
+        specM.setEncodingProperty(1, Property.CHANNEL, channel, {enum: [Channel.SHAPE, Channel.SIZE, Channel.COLOR]});
+        assert.isFalse(SPEC_CONSTRAINT_INDEX['omitNonPositionalOverPositionalChannels'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+      });
+    });
+
+    it('should return false if color/shape/size is manually specified if either x or y is not used and we constraintManuallySpecifiedValue', () => {
       [Channel.SHAPE, Channel.SIZE, Channel.COLOR].forEach((channel) => {
         const specM = buildSpecQueryModel({
           mark: Mark.POINT,
@@ -957,7 +971,20 @@ describe('constraints/spec', () => {
             {channel: channel, field: 'C', type: Type.NOMINAL}
           ]
         });
-        assert.isFalse(SPEC_CONSTRAINT_INDEX['omitNonPositionalOverPositionalChannels'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+        assert.isFalse(SPEC_CONSTRAINT_INDEX['omitNonPositionalOverPositionalChannels'].satisfy(specM, schema, CONSTRAINT_MANUALLY_SPECIFIED_CONFIG));
+      });
+    });
+
+    it('should return true if color/shape/size is manually specified even when either x or y is not used', () => {
+      [Channel.SHAPE, Channel.SIZE, Channel.COLOR].forEach((channel) => {
+        const specM = buildSpecQueryModel({
+          mark: Mark.POINT,
+          encodings: [
+            {channel: Channel.X, field: 'A', type: Type.NOMINAL},
+            {channel: channel, field: 'C', type: Type.NOMINAL}
+          ]
+        });
+        assert.isTrue(SPEC_CONSTRAINT_INDEX['omitNonPositionalOverPositionalChannels'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
       });
     });
   });

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -505,7 +505,20 @@ describe('constraints/spec', () => {
   });
 
   describe('omitAggregatePlotWithDimensionOnlyOnFacet', () => {
-    it('should return false if the only dimension is facet', () => {
+    it('should return false if the only dimension is facet and it is enumerated', () => {
+      const specM = buildSpecQueryModel({
+        mark: Mark.POINT,
+        encodings: [
+          {channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE, aggregate: AggregateOp.MEAN},
+          {channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE, aggregate: AggregateOp.MEAN},
+          {channel: {enum: [Channel.ROW]}, field: 'N', type: Type.NOMINAL}
+        ]
+      });
+      specM.setEncodingProperty(2, Property.CHANNEL, Channel.ROW, {enum: [Channel.ROW]});
+      assert.isFalse(SPEC_CONSTRAINT_INDEX['omitAggregatePlotWithDimensionOnlyOnFacet'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+    });
+
+    it('should return true if the only dimension is facet and it is specified', () => {
       const specM = buildSpecQueryModel({
         mark: Mark.POINT,
         encodings: [
@@ -514,7 +527,19 @@ describe('constraints/spec', () => {
           {channel: Channel.ROW, field: 'N', type: Type.NOMINAL}
         ]
       });
-      assert.isFalse(SPEC_CONSTRAINT_INDEX['omitAggregatePlotWithDimensionOnlyOnFacet'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+      assert.isTrue(SPEC_CONSTRAINT_INDEX['omitAggregatePlotWithDimensionOnlyOnFacet'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+    });
+
+    it('should return false if the only dimension is facet and it is specified when we constraintManuallySpecifiedValue', () => {
+      const specM = buildSpecQueryModel({
+        mark: Mark.POINT,
+        encodings: [
+          {channel: Channel.X, field: 'Q', type: Type.QUANTITATIVE, aggregate: AggregateOp.MEAN},
+          {channel: Channel.Y, field: 'Q1', type: Type.QUANTITATIVE, aggregate: AggregateOp.MEAN},
+          {channel: Channel.ROW, field: 'N', type: Type.NOMINAL}
+        ]
+      });
+      assert.isFalse(SPEC_CONSTRAINT_INDEX['omitAggregatePlotWithDimensionOnlyOnFacet'].satisfy(specM, schema, CONSTRAINT_MANUALLY_SPECIFIED_CONFIG));
     });
 
     it('should return true if the only dimension is not facet', () => {

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -1142,7 +1142,19 @@ describe('constraints/spec', () => {
       assert.isTrue(SPEC_CONSTRAINT_INDEX['omitRawDetail'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
     });
 
-    it('should return false when raw data has a detail channel', () => {
+    it('should return false when raw data has an enumerated detail channel', () => {
+      const specM = buildSpecQueryModel({
+        mark: Mark.POINT,
+        encodings: [
+          {channel: {enum: [Channel.DETAIL]}, field: 'A', type: Type.NOMINAL}
+        ]
+      });
+      specM.setEncodingProperty(0, Property.CHANNEL, Channel.DETAIL, {enum: [Channel.DETAIL]});
+
+      assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRawDetail'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+    });
+
+    it('should return true when raw data has a manually specified detail channel', () => {
       const specM = buildSpecQueryModel({
         mark: Mark.POINT,
         encodings: [
@@ -1150,7 +1162,18 @@ describe('constraints/spec', () => {
         ]
       });
 
-      assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRawDetail'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+      assert.isTrue(SPEC_CONSTRAINT_INDEX['omitRawDetail'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+    });
+
+    it('should return false when we constraintManuallySpecifiedValue raw data has a manually specified detail channel', () => {
+      const specM = buildSpecQueryModel({
+        mark: Mark.POINT,
+        encodings: [
+          {channel: Channel.DETAIL, field: 'A', type: Type.NOMINAL}
+        ]
+      });
+
+      assert.isFalse(SPEC_CONSTRAINT_INDEX['omitRawDetail'].satisfy(specM, schema, CONSTRAINT_MANUALLY_SPECIFIED_CONFIG));
     });
 
     it('should return true if any of the encoding channels contain aggregate', () => {

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -51,7 +51,7 @@ describe('generate', function () {
         assert.equal(answerSet[1].getEncodingQueryByIndex(0).channel, Channel.Y);
       });
 
-      it('should only enumerate channel x and channel y even if omitNonPositionalOverPositionalChannels turned off', () => {
+      it('should only enumerate channel x and channel y even if omitNonPositionalOrFacetOverPositionalChannels turned off', () => {
         const query = {
           mark: Mark.POINT,
           encodings: [{
@@ -60,7 +60,7 @@ describe('generate', function () {
             type: Type.QUANTITATIVE
           }]
         };
-        const answerSet = generate(query, schema, extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOverPositionalChannels: false}));
+        const answerSet = generate(query, schema, extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOrFacetOverPositionalChannels: false}));
         assert.equal(answerSet.length, 2);
         assert.equal(answerSet[0].getEncodingQueryByIndex(0).channel, Channel.X);
         assert.equal(answerSet[1].getEncodingQueryByIndex(0).channel, Channel.Y);
@@ -95,7 +95,7 @@ describe('generate', function () {
           }]
         };
 
-        const answerSet = generate(query, schema, extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOverPositionalChannels: false}));
+        const answerSet = generate(query, schema, extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOrFacetOverPositionalChannels: false}));
         assert.equal(answerSet.length, 4);
 
         assert.equal(answerSet[0].getMark(), Mark.POINT);

--- a/test/nest.test.ts
+++ b/test/nest.test.ts
@@ -689,7 +689,7 @@ describe('nest', () => {
             }]
           },
           nest: [{groupBy: groupBy}],
-          config: extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOverPositionalChannels: false})
+          config: extend({}, DEFAULT_QUERY_CONFIG, {omitNonPositionalOrFacetOverPositionalChannels: false})
         };
 
         const answerSet = generate(query.spec, schema, query.config);


### PR DESCRIPTION
Relax many constraints to return false only if one of the violating channel is enumerated or if the new `constraintManuallySpecifiedValue` is enabled.  



(Addressing https://github.com/uwdata/compassql/issues/248#issuecomment-242878786 for important constraints) 
