### PR TITLE
Add support enum spec for mark, channel, field, type, and bin's parameters (#263)

### DIFF
--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -29,12 +29,24 @@ export function getReplacer(replace: Dict<string>): Replacer {
   };
 }
 
-export function value(v: any, replace: Replacer): any {
+export function value(v: any, replacer: Replacer): any {
   if (isEnumSpec(v)) {
-    return SHORT_ENUM_SPEC;
+    // Return the enum array if it's a full enum spec, or just return SHORT_ENUM_SPEC for short ones.
+    if (v.enum) {
+      return SHORT_ENUM_SPEC + JSON.stringify(v.enum);
+    } else {
+      return SHORT_ENUM_SPEC;
+    }
   }
-  if (replace) {
-    return replace(v);
+  if (replacer) {
+    return replacer(v);
+  }
+  return v;
+}
+
+export function replace(v: any, replacer: Replacer): any {
+  if (replacer) {
+    return replacer(v);
   }
   return v;
 }
@@ -172,7 +184,7 @@ export function encoding(encQ: EncodingQuery,
  */
 export function fieldDef(encQ: EncodingQuery,
     include: Dict<boolean> = INCLUDE_ALL,
-    replace: Dict<Replacer> = {}): string {
+    replacer: Dict<Replacer> = {}): string {
 
   let fn = null, fnEnumIndex = null;
 
@@ -182,11 +194,11 @@ export function fieldDef(encQ: EncodingQuery,
   if (include[Property.AGGREGATE] && encQ.autoCount === false) {
     return '-';
   } else if (include[Property.AGGREGATE] && encQ.aggregate && !isEnumSpec(encQ.aggregate)) {
-    fn = value(encQ.aggregate, replace[Property.AGGREGATE]);
+    fn = replace(encQ.aggregate, replacer[Property.AGGREGATE]);
   } else if (include[Property.AGGREGATE] && encQ.autoCount && !isEnumSpec(encQ.autoCount)) {
-    fn = value('count', replace[Property.AGGREGATE]);;
+    fn = replace('count', replacer[Property.AGGREGATE]);;
   } else if (include[Property.TIMEUNIT] && encQ.timeUnit && !isEnumSpec(encQ.timeUnit)) {
-    fn = value(encQ.timeUnit, replace[Property.TIMEUNIT]);
+    fn = replace(encQ.timeUnit, replacer[Property.TIMEUNIT]);
   } else if (include[Property.BIN] && encQ.bin && !isEnumSpec(encQ.bin)) {
     fn = 'bin';
 
@@ -195,7 +207,7 @@ export function fieldDef(encQ: EncodingQuery,
     if (include[Property.BIN_MAXBINS] && encQ.bin['maxbins']) {
       props.push({
         key: 'maxbins',
-        value: value(encQ.bin['maxbins'], replace[Property.BIN_MAXBINS])
+        value: value(encQ.bin['maxbins'], replacer[Property.BIN_MAXBINS])
       });
     }
   } else {
@@ -213,7 +225,7 @@ export function fieldDef(encQ: EncodingQuery,
           if (include[Property.BIN_MAXBINS] && encQ.bin['maxbins']) {
             props.push({
               key: 'maxbins',
-              value: value(encQ.bin['maxbins'], replace[Property.BIN_MAXBINS])
+              value: value(encQ.bin['maxbins'], replacer[Property.BIN_MAXBINS])
             });
           }
         }
@@ -241,7 +253,7 @@ export function fieldDef(encQ: EncodingQuery,
           const nestedProps = getNestedEncodingPropertyChildren(nestedPropParent);
           const nestedPropChildren = nestedProps.reduce((p, nestedProp) => {
             if (include[nestedProp.property] && encQ[nestedPropParent][nestedProp.child] !== undefined) {
-              p[nestedProp.child] = value(encQ[nestedPropParent][nestedProp.child], replace[nestedProp.property]);
+              p[nestedProp.child] = replace(encQ[nestedPropParent][nestedProp.child], replacer[nestedProp.property]);
             }
             return p;
           }, {});
@@ -264,11 +276,15 @@ export function fieldDef(encQ: EncodingQuery,
   }
 
   // field
-  let fieldAndParams = include[Property.FIELD] ? value(encQ.field || '*', replace[Property.FIELD]) : '...';
+  let fieldAndParams = include[Property.FIELD] ? value(encQ.field || '*', replacer[Property.FIELD]) : '...';
   // type
   if (include[Property.TYPE]) {
-    const typeShort = ((encQ.type || Type.QUANTITATIVE)+'').substr(0,1);
-    fieldAndParams += ',' + value(typeShort, replace[Property.TYPE]);
+    if (isEnumSpec(encQ.type)) {
+      fieldAndParams += ',' + value(encQ.type, replacer[Property.TYPE]);
+    } else {
+      const typeShort = ((encQ.type || Type.QUANTITATIVE)+'').substr(0,1);
+      fieldAndParams += ',' + value(typeShort, replacer[Property.TYPE]);
+    }
   }
   // encoding properties
   fieldAndParams += props.map((p) => ',' + p.key + '=' + p.value).join('');

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -101,6 +101,17 @@ describe('query/shorthand', () => {
       assert.equal(str, 'a');
     });
 
+    it('should return correct spec string for ambiguous mark, channel, field, and type', () => {
+      const str = specShorthand({
+        mark: {enum: [Mark.POINT, Mark.TICK]},
+        encodings: [
+          {channel: {name: 'c1', enum: [Channel.X, Channel.Y]}, field: {enum: ['field1', 'field2']}, type: {enum: [Type.NOMINAL, Type.ORDINAL]}, aggregate: SHORT_ENUM_SPEC, bin: SHORT_ENUM_SPEC}
+        ]
+      });
+
+      assert.equal(str, '?["point","tick"]|?["x","y"]:?{"aggregate":"?","bin":"?"}(?["blah1","blah2"],?["nominal","ordinal"])');
+    });
+
     it('should return correct spec string for ambiguous specQuery', () => {
       const str = specShorthand({
         mark: SHORT_ENUM_SPEC,
@@ -193,6 +204,16 @@ describe('query/shorthand', () => {
     it('should return correct encoding string for raw field', () => {
        const str = encodingShorthand({channel: Channel.X, field: 'a', type: Type.QUANTITATIVE});
        assert.equal(str, 'x:a,q');
+    });
+
+    it('should return correct encoding string for channel as short enum spec', () => {
+      const str = encodingShorthand({channel: '?', field: 'a', type: Type.QUANTITATIVE});
+      assert.equal(str, '?:a,q');
+    });
+
+    it('should return correct encoding string for bin with maxbins as enum spec and channel as enum spec', () => {
+      const str = encodingShorthand({bin: {maxbins: {enum: [10, 20]}}, channel: {enum: [Channel.X, Channel.Y]}, field: 'a', type: Type.QUANTITATIVE});
+      assert.equal(str, '?["x","y"]:bin(a,q,maxbins=?[10,20])');
     });
 
     it('should return correct encoding string for raw field when channel is not included', () => {

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -105,7 +105,13 @@ describe('query/shorthand', () => {
       const str = specShorthand({
         mark: {enum: [Mark.POINT, Mark.TICK]},
         encodings: [
-          {channel: {name: 'c1', enum: [Channel.X, Channel.Y]}, field: {enum: ['field1', 'field2']}, type: {enum: [Type.NOMINAL, Type.ORDINAL]}, aggregate: SHORT_ENUM_SPEC, bin: SHORT_ENUM_SPEC}
+          {
+            channel: {name: 'c1', enum: [Channel.X, Channel.Y]},
+            field: {enum: ['field1', 'field2']},
+            type: {enum: [Type.NOMINAL, Type.ORDINAL]},
+            aggregate: SHORT_ENUM_SPEC,
+            bin: SHORT_ENUM_SPEC
+          }
         ]
       });
 

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -109,7 +109,7 @@ describe('query/shorthand', () => {
         ]
       });
 
-      assert.equal(str, '?["point","tick"]|?["x","y"]:?{"aggregate":"?","bin":"?"}(?["blah1","blah2"],?["nominal","ordinal"])');
+      assert.equal(str, '?["point","tick"]|?["x","y"]:?{"aggregate":"?","bin":"?"}(?["field1","field2"],?["nominal","ordinal"])');
     });
 
     it('should return correct spec string for ambiguous specQuery', () => {


### PR DESCRIPTION
- Add shorthand support for mark, channel, field, type, and bin parameters as enumspec
- Add relevant tests