### PR TITLE
Update calculate's shorthand and test

### DIFF
--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -153,9 +153,12 @@ export function spec(specQ: SpecQuery,
 }
 
 export function calculate(formulaArr: Formula[]): string {
-  return '{' + formulaArr.map(function(calculateItem) {
-    return `${calculateItem.field}:${calculateItem.expr}`;
-  }).join(',') + '}';
+  return JSON.stringify(
+    formulaArr.reduce((m, calculateItem) => {
+      m[calculateItem.field] = calculateItem.expr;
+      return m;
+    }, {})
+  );
 }
 
 /**

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -153,9 +153,9 @@ export function spec(specQ: SpecQuery,
 }
 
 export function calculate(formulaArr: Formula[]): string {
-  return formulaArr.map(function(calculateItem) {
-    return `{${calculateItem.field}:${calculateItem.expr}}`;
-  }).join(',');
+  return '{' + formulaArr.map(function(calculateItem) {
+    return `${calculateItem.field}:${calculateItem.expr}`;
+  }).join(',') + '}';
 }
 
 /**

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -176,7 +176,7 @@ describe('query/shorthand', () => {
       const str = calculateShorthand([
         {field: 'b2', expr: '2*datum["b"]'}, {field: 'a', expr:'3*datum["a"]'}
       ]);
-      assert.equal(str, '{b2:2*datum["b"]},{a:3*datum["a"]}');
+      assert.equal(str, '{b2:2*datum["b"],a:3*datum["a"]}');
     });
   });
 

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -29,7 +29,7 @@ describe('query/shorthand', () => {
         encoding: {
           x: {field: 'x', type: Type.QUANTITATIVE}
         }
-      }), 'point|calculate:{x2:datum.x*2}|filter:"datum.x === 5"|x:x,q');
+      }), 'point|calculate:{"x2":"datum.x*2"}|filter:"datum.x === 5"|x:x,q');
     });
   });
 
@@ -140,7 +140,7 @@ describe('query/shorthand', () => {
           {channel: Channel.X, field: 'b2', type: Type.QUANTITATIVE}
         ]
       });
-      assert.equal(str, 'point|calculate:{b2:3*datum["b2"]}|filter:"datum[\\"b2\\"] > 60"|filterInvalid:false|x:b2,q');
+      assert.equal(str, 'point|calculate:{"b2":"3*datum[\\"b2\\"]"}|filter:"datum[\\"b2\\"] > 60"|filterInvalid:false|x:b2,q');
     });
 
     it('should return correct spec string for a specific specQuery with transform filter and calculate', () => {
@@ -176,7 +176,7 @@ describe('query/shorthand', () => {
       const str = calculateShorthand([
         {field: 'b2', expr: '2*datum["b"]'}, {field: 'a', expr:'3*datum["a"]'}
       ]);
-      assert.equal(str, '{b2:2*datum["b"],a:3*datum["a"]}');
+      assert.equal(str, '{"b2":"2*datum[\\"b\\"]","a":"3*datum[\\"a\\"]"}');
     });
   });
 


### PR DESCRIPTION
Fix #260 

Calculate shorthand is now in the form of calculate:{field1:expr1,field2:expr2}
